### PR TITLE
Add gulpfile.babel.js as a valid gulp file

### DIFF
--- a/src/material-icons.json
+++ b/src/material-icons.json
@@ -1044,6 +1044,7 @@
     ".io-config.json": "_file_ionic",
     "gulpfile.js": "_file_gulp",
     "gulpfile.ts": "_file_gulp",
+    "gulpfile.babel.js": "_file_gulp",
     "package.json": "_file_nodejs",
     "gradle.properties": "_file_gradle",
     "gradlew": "_file_gradle",


### PR DESCRIPTION
`gulpfile.babel.js` is a popular naming convention for gulp configuration that needs to be compiled using babel (e.g. written in ES6).

I've added it as a valid filename for files that fall under the gulp category.