### PR TITLE
Add support for .env.example

### DIFF
--- a/src/material-icons.json
+++ b/src/material-icons.json
@@ -1068,6 +1068,7 @@
     "androidmanifest.xml": "_file_android",
     "gradle-wrapper.properties": "_file_gradle",
     ".env": "_file_tune",
+    ".env.example": "_file_tune",
     "dockerfile": "_file_docker",
     "license": "_file_certificate",
     "license.md": "_file_certificate",


### PR DESCRIPTION
The `.env.example` file is generally used as a template for `.env` files. It is tracked by source control, but not used as the actual configuration.

This PR gives it the same icon as `.env`.