### PR TITLE
adds .pks and .pkb file detection

### DIFF
--- a/src/material-icons.json
+++ b/src/material-icons.json
@@ -821,6 +821,8 @@
     "settings": "_file_settings",
     "option": "_file_settings",
     "sql": "_file_database",
+    "pks": "_file_database",
+    "pkb": "_file_database",
     "accdb": "_file_database",
     "mdb": "_file_database",
     "cer": "_file_certificate",


### PR DESCRIPTION
These are commonly used extensions for Oracle PL/SQL files and should also show the database icon.