### PR TITLE
added I18N Simplified Chinese

### DIFF
--- a/src/i18n/lang-zh-cn.ts
+++ b/src/i18n/lang-zh-cn.ts
@@ -1,0 +1,49 @@
+import { Translation } from "../models/Translation.interface";
+
+export const translation: Translation = {
+    "themeInstalled": "Material主题图标已安装",
+    "howToActivate": "如何激活图标",
+    "activate": "激活",
+    "activated": "Material主题图标已激活",
+    "neverShowAgain": "不再显示",
+    "themeUpdated": "Material主题图标已更新",
+    "readChangelog": "阅读更新日志",
+    "angular": {
+        "alreadyEnabled": "已启用Angular图标",
+        "alreadyDisabled": "已禁用Angular图标",
+        "enableIcons": "启用Angular图标",
+        "disableIcons": "禁用Angular图标",
+        "toggleIcons": "切换Angular图标的显示"
+    },
+    "folders": {
+        "alreadyEnabled": "文件夹图标已启用",
+        "alreadyDisabled": "文件夹图标已禁用",
+        "enableIcons": "启用文件夹图标",
+        "disableIcons": "禁用文件夹图标",
+        "toggleIcons": "切换文件夹图标的显示",
+        "specific": {
+            "name": "多彩",
+            "description": "多彩的文件夹图标"
+        },
+        "classic": {
+            "name": "经典",
+            "description": "灰色主题的文件夹图标"
+        },
+        "blue": {
+            "name": "蓝色",
+            "description": "蓝色主题的文件夹图标"
+        },
+        "none": {
+            "name": "无",
+            "description": "不显示文件夹图标"
+        }
+    },
+    "toggleSwitch": {
+        "on": "ON",
+        "off": "OFF"
+    },
+    "confirmReload": "你必须重启VS Code来应用对图标的更改",
+    "reload": "重启",
+    "outdatedVersion": "你必须更新VS Code才能使用该命令",
+    "updateVSCode": "更新VS Code"
+};


### PR DESCRIPTION
Hi! Thanks for so many cool material icons.
Added support for `locale: zh-CN` which is simplified Chinese language to prevent the error `Cannot find module './lang-zh-cn'` when developing other VS Code extensions.