### PR TITLE
fixed bug in change detection

### DIFF
--- a/src/helpers/change-detection.ts
+++ b/src/helpers/change-detection.ts
@@ -26,7 +26,7 @@ const compareAngularConfigs = () => {
 
     return checkAngularIconsStatus().then(result => {
         // if the settings are different to the current material-icons.json file
-        if (angularIconsConfig.globalValue !== result) {
+        if (angularIconsConfig.globalValue !== undefined && angularIconsConfig.globalValue !== result) {
             if (angularIconsConfig.globalValue === true) {
                 enableAngularIcons();
             } else if (angularIconsConfig.globalValue === false) {


### PR DESCRIPTION
Check if the global value is not undefined. Otherwise it will prompt to restart every time because undefined !== true (true by default)