### PR TITLE
Add Language Mode "javascriptreact"

### DIFF
--- a/src/material-icons.json
+++ b/src/material-icons.json
@@ -33,9 +33,6 @@
     "_file_js": {
       "iconPath": "./../../icons/javascript.svg"
     },
-    "_file_jsreact": {
-      "iconPath": "./../../icons/react.svg"
-    },
     "_file_ts": {
       "iconPath": "./../../icons/typescript.svg"
     },
@@ -1456,7 +1453,7 @@
     "razor": "_file_razor",
     "python": "_file_python",
     "javascript": "_file_js",
-    "javascriptreact": "_file_jsreact",
+    "javascriptreact": "_file_react",
     "typescript": "_file_ts",
     "scala": "_file_scala",
     "handlebars": "_file_handlebars",

--- a/src/material-icons.json
+++ b/src/material-icons.json
@@ -33,6 +33,9 @@
     "_file_js": {
       "iconPath": "./../../icons/javascript.svg"
     },
+    "_file_jsreact": {
+      "iconPath": "./../../icons/react.svg"
+    },
     "_file_ts": {
       "iconPath": "./../../icons/typescript.svg"
     },
@@ -1453,6 +1456,7 @@
     "razor": "_file_razor",
     "python": "_file_python",
     "javascript": "_file_js",
+    "javascriptreact": "_file_jsreact",
     "typescript": "_file_ts",
     "scala": "_file_scala",
     "handlebars": "_file_handlebars",


### PR DESCRIPTION
"javascriptreact" is a language mode that replace the default "javascript" mode when a .js is opened in vscode. This can be done via the settings: 

````json
{
  "files.associations": {
    "*.js": "javascriptreact"
  }
}
````
So I choose the already present "react.svg" file inside the icons folder to do the maching.