### PR TITLE
Added .babelrc.js to babel associations

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -514,7 +514,7 @@ export const fileIcons: FileIcons = {
         },
         { name: 'android', fileNames: ['androidmanifest.xml'] },
         { name: 'tune', fileNames: ['.env', '.env.example'] },
-        { name: 'babel', fileNames: ['.babelrc'] },
+        { name: 'babel', fileNames: ['.babelrc', '.babelrc.js'] },
         {
             name: 'contributing',
             fileNames: ['contributing.md', 'contributing.md.rendered']


### PR DESCRIPTION
Babel's upcoming v7 will add support for [`.babelrc.js` config file](https://babeljs.io/blog/2017/09/12/planning-for-7.0#babelrcjs). I updated the file association for babel to include this file. Is this the right place to add it?