### PR TITLE
Added docker icon to the docker-compose.override.yml file

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -224,7 +224,7 @@ export const fileIcons: FileIcons = {
         {
             name: 'docker',
             fileExtensions: ['dockerignore', 'dockerfile'],
-            fileNames: ['dockerfile', 'docker-compose.yml']
+            fileNames: ['dockerfile', 'docker-compose.yml', 'docker-compose.override.yml']
         },
         { name: 'tex', fileExtensions: ['tex', 'cls', 'sty'] },
         {


### PR DESCRIPTION
Added recognition for `docker-compose.override.yml` as a standard Docker file, with the standard Docker icon.