### PR TITLE
Adds docker-compose.yaml file association

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -226,7 +226,12 @@ export const fileIcons: FileIcons = {
         {
             name: 'docker',
             fileExtensions: ['dockerignore', 'dockerfile'],
-            fileNames: ['dockerfile', 'docker-compose.yml', 'docker-compose.override.yml']
+            fileNames: [
+                'dockerfile',
+                'docker-compose.yml',
+                'docker-compose.yaml',
+                'docker-compose.override.yml'
+            ]
         },
         { name: 'tex', fileExtensions: ['tex', 'cls', 'sty'] },
         {


### PR DESCRIPTION
Currently `docker-compose.yaml` file icon is default `.yaml` icon, but `docker-compose.yml` is the Docker icon.

This adds `docker-compose.yaml` to the list of files using the docker icon.