### PR TITLE
Assign the `console` icon to .fish files

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -170,7 +170,18 @@ export const fileIcons: FileIcons = {
         { name: 'url', fileExtensions: ['url'] },
         {
             name: 'console',
-            fileExtensions: ['sh', 'ksh', 'csh', 'tcsh', 'zsh', 'bash', 'bat', 'cmd', 'awk']
+            fileExtensions: [
+                'sh',
+                'ksh',
+                'csh',
+                'tcsh',
+                'zsh',
+                'bash',
+                'bat',
+                'cmd',
+                'awk',
+                'fish'
+            ]
         },
         {
             name: 'powershell',


### PR DESCRIPTION
Fish shell scripts with the `.fish` extension currently do not have an icon assigned to them. This fixes that, treating Fish shell scripts like other shell scripts.