### PR TITLE
Add HashiCorp Configuration Language (.hcl) Icon

### DIFF
--- a/icons/hcl.svg
+++ b/icons/hcl.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;">
+    <g id="Logo" transform="matrix(0.188962,0,0,0.188962,1.9,1.31422)">
+        <path d="M44.5,0L0,25.7L0,87.4L16.7,97.1L16.7,35.3L44.5,19.3L44.5,0Z" style="fill:white;fill-rule:nonzero;"/>
+        <path d="M62.3,0L62.3,49.2L44.5,49.2L44.5,30.8L27.8,40.5L27.8,103.4L44.5,113.1L44.5,64.1L62.3,64.1L62.3,82.3L79.1,72.7L79.1,9.7L62.3,0Z" style="fill:white;fill-rule:nonzero;"/>
+        <path d="M62.3,113.1L106.9,87.4L106.9,25.7L90.1,16.1L90.1,77.8L62.3,93.8L62.3,113.1Z" style="fill:white;fill-rule:nonzero;"/>
+    </g>
+</svg>

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -660,5 +660,6 @@ export const fileIcons: FileIcons = {
         { name: 'storybook', fileExtensions: ['stories.js', 'stories.jsx', 'story.js', 'story.jsx'] },
         { name: 'wepy', fileExtensions: ['wpy'] },
         { name: 'fastlane', fileNames: ['fastfile', 'appfile'] },
+        { name: 'hcl', fileNames: ['hcl'] },
     ]
 };

--- a/src/icons/languageIcons.ts
+++ b/src/icons/languageIcons.ts
@@ -65,4 +65,5 @@ export const languageIcons: LanguageIcon[] = [
     { icon: { name: 'react' }, ids: ['javascriptreact'] },
     { icon: { name: 'mjml' }, ids: ['mjml'] },
     { icon: { name: 'processing' }, ids: ['processing'] },
+    { icon: { name: 'hcl' }, ids: ['hcl'] },
 ];


### PR DESCRIPTION
Add an icon for the .hcl file extension used by many of the HashiCorp suite.