### PR TITLE
add bitbucket icon for bitbucket pipeline yaml files

### DIFF
--- a/icons/bitbucket.svg
+++ b/icons/bitbucket.svg
@@ -1,0 +1,11 @@
+<svg width="512" height="512" xmlns="http://www.w3.org/2000/svg" class="svg-inline--fa fa-bitbucket fa-w-16">
+
+ <g>
+  <title>background</title>
+  <rect fill="none" id="canvas_background" height="402" width="582" y="-1" x="-1"/>
+ </g>
+ <g>
+  <title>Layer 1</title>
+  <path id="svg_1" d="m23.1,32c-8.9,-0.1 -16.1,6.9 -16.2,15.8c0,0.9 0.1,1.8 0.2,2.8l67.8,411.4c1.7,10.4 10.7,18 21.2,18.1l325.1,0c7.9,0.1 14.7,-5.6 16,-13.4l67.8,-416c1.4,-8.7 -4.5,-16.9 -13.2,-18.3c-0.9,-0.1 -1.8,-0.2 -2.8,-0.2l-465.9,-0.2zm285.3,297.3l-103.8,0l-28.1,-146.8l157,0l-25.1,146.8z" fill="#1565c0"/>
+ </g>
+</svg>

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -719,5 +719,6 @@ export const fileIcons: FileIcons = {
         { name: 'i18n', fileExtensions: ['pot', 'po', 'mo'] },
         { name: 'webassembly', fileExtensions: ['wat', 'wasm'] },
         { name: 'semantic-release', light: true, fileNames: ['.releaserc', 'release.config.js'] },
+        { name: 'bitbucket', fileNames: ['bitbucket-pipelines'], fileExtensions: [ 'yml', 'yaml' ] }
     ]
 };


### PR DESCRIPTION
Pretty straightforward. Added an icon for bitbucket pipelines config file.
https://bitbucket.org/product/features/pipelines

The icon came from font awesome's free brand icons collection. The color is blue 800 from the material design color swatches.
https://material.io/design/color/the-color-system.html#tools-for-picking-colors