### PR TITLE
Add babel.config.js to the babel association list

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -570,7 +570,7 @@ export const fileIcons: FileIcons = {
                 '.env.prod',
             ]
         },
-        { name: 'babel', fileNames: ['.babelrc', '.babelrc.js'] },
+        { name: 'babel', fileNames: ['.babelrc', '.babelrc.js', 'babel.config.js'] },
         {
             name: 'contributing',
             fileNames: ['contributing.md', 'contributing.md.rendered']


### PR DESCRIPTION
Babel@7 also introduce `babel.config.js` as a valid babel configuration file. (reference here: https://babeljs.io/docs/en/next/babelconfigjs.html)