### PR TITLE
Added docker-compose-prod file icon

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -269,7 +269,8 @@ export const fileIcons: FileIcons = {
                 'dockerfile',
                 'docker-compose.yml',
                 'docker-compose.yaml',
-                'docker-compose.override.yml'
+                'docker-compose.override.yml',
+		'docker-compose.prod.yml'
             ]
         },
         { name: 'tex', fileExtensions: ['tex', 'cls', 'sty'] },

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -270,7 +270,7 @@ export const fileIcons: FileIcons = {
                 'docker-compose.yml',
                 'docker-compose.yaml',
                 'docker-compose.override.yml',
-		'docker-compose.prod.yml'
+                'docker-compose.prod.yml'
             ]
         },
         { name: 'tex', fileExtensions: ['tex', 'cls', 'sty'] },


### PR DESCRIPTION
Sometimes `docker-compose-prod.yml` file is used. Currently Material Icon Theme does not support this file association.

See: https://docs.docker.com/compose/extends/#example-use-case