### PR TITLE
Add support for `stencil.config.ts` for Stencil icon

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -713,7 +713,7 @@ export const fileIcons: FileIcons = {
         { name: 'san', fileExtensions: ['san'] },
         { name: 'wallaby', fileNames: ['wallaby.js', 'wallaby.conf.js'] },
         { name: 'django', fileExtensions: ['djt'] },
-        { name: 'stencil', fileNames: ['stencil.config.js'], light: true },
+        { name: 'stencil', fileNames: ['stencil.config.js', 'stencil.config.ts'], light: true },
         { name: 'red', fileExtensions: ['red'] },
         { name: 'makefile', fileNames: ['makefile'] },
         { name: 'foxpro', fileExtensions: ['fxp', 'prg'] },


### PR DESCRIPTION
[Stencil](https://github.com/ionic-team/stencil/) recently [added support](https://github.com/ionic-team/stencil/blob/master/CHANGELOG.md#-0110-2018-07-31) for typed `stencil.config.ts` files in v0.11.0.

This PR simply expands support for the existing Stencil icon to include the new Typescript config file.