### PR TITLE
Add support for `AUTHORS`

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -583,7 +583,7 @@ export const fileIcons: FileIcons = {
         },
         {
             name: 'credits',
-            fileNames: ['CREDITS', 'credits.txt', 'credits.md', 'credits.md.rendered']
+            fileNames: ['authors', 'authors.md', 'authors.txt', 'credits', 'credits.txt', 'credits.md', 'credits.md.rendered']
         },
         { name: 'flow', fileNames: ['.flowconfig'] },
         { name: 'favicon', fileNames: ['favicon.ico'] },


### PR DESCRIPTION
Extended the `credits` icon for use with `AUTHORS`, `AUTHORS.md`, and `AUTHORS.txt` files. The usage is pretty much the same between the authors and credits - figured the icon could be same.