### PR TITLE
Added file prefix to puppeteer page link

### DIFF
--- a/scripts/preview/screenshots.ts
+++ b/scripts/preview/screenshots.ts
@@ -11,7 +11,8 @@ export const createScreenshots = async (filePath: string, fileName: string) => {
         width: 100
     });
 
-    await page.goto(htmlFilePath);
+    await page.goto(`file:${htmlFilePath}`);
+
     await page.screenshot({
         path: `images/${fileName}.png`,
         omitBackground: false,


### PR DESCRIPTION
Puppeteer was not creating file icons previews without `file:` prefix inside before HTML path inside `page.goto` method.