### PR TITLE
Adding Visual Studio C++ configuration files & .clang-tidy

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -174,7 +174,7 @@ export const fileIcons: FileIcons = {
                 'vb',
                 'vbs',
                 'vcxitems',
-                'vcxitems.filters'
+                'vcxitems.filters',
                 'vcxproj',
                 'vcxproj.filters'
             ]

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -152,6 +152,7 @@ export const fileIcons: FileIcons = {
                 '.yardopts',
                 'manifest.mf',
                 '.clang-format',
+                '.clang-tidy'
             ]
         },
         { name: 'typescript', fileExtensions: ['ts'] },
@@ -163,7 +164,21 @@ export const fileIcons: FileIcons = {
             name: 'vscode',
             fileExtensions: ['vscodeignore', 'vsixmanifest', 'vsix', 'code-workplace']
         },
-        { name: 'visualstudio', fileExtensions: ['suo', 'sln', 'csproj', 'vb', 'vbs'] },
+        {
+            name: 'visualstudio',
+            fileExtensions: [
+                'csproj',
+                'ruleset',
+                'sln',
+                'suo',
+                'vb',
+                'vbs',
+                'vcxitems',
+                'vcxitems.filters'
+                'vcxproj',
+                'vcxproj.filters'
+            ]
+        },
         {
             name: 'database',
             fileExtensions: ['pdb', 'sql', 'pks', 'pkb', 'accdb', 'mdb', 'sqlite', 'pgsql', 'postgres', 'psql']


### PR DESCRIPTION
A set of configuration files specific to Visual Studio:
- `*.vcxproj` The default Visual C++ project file.
- `*.vcxitems` A non-compiled "Shared items" project.
- `*.*.filters` Per project file grouping and filtering configuration in Visual Studio.
- `*.ruleset` Custom configuration for error/warning handling.

And adding the `.clang-tidy` configuration file with the existing mention of `.clang-format` under settings.