### PR TITLE
Added dot-file-style for AppVeyor

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -632,7 +632,7 @@ export const fileIcons: FileIcons = {
             ]
         },
         { name: 'bithound', fileNames: ['.bithoundrc'] },
-        { name: 'appveyor', fileNames: ['appveyor.yml'] },
+        { name: 'appveyor', fileNames: ['.appveyor.yml', 'appveyor.yml'] },
         { name: 'travis', fileNames: ['.travis.yml'] },
         {
             name: 'protractor',


### PR DESCRIPTION
The title is self explanatory. According to the [documentation](https://www.appveyor.com/docs/build-configuration/#yaml-file-alternative-naming), this name is supported out of the box.

Some people might prefer to keep all of the CI configuration under the same format (`.gitlab-ci.yml`, `.travis.yml` and `.appveyor.yml`).

A little preview:
![Wah](https://user-images.githubusercontent.com/11861253/50671810-e27dc780-0fb2-11e9-88bf-7b16cb598f35.png)
