### PR TITLE
Added app.json as a Heroku file

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -645,7 +645,7 @@ export const fileIcons: FileIcons = {
             ]
         },
         { name: 'fusebox', fileNames: ['fuse.js'] },
-        { name: 'heroku', fileNames: ['procfile', 'procfile.windows'] },
+        { name: 'heroku', fileNames: ['app.json', 'procfile', 'procfile.windows'] },
         { name: 'editorconfig', fileNames: ['.editorconfig'] },
         { name: 'gitlab', fileNames: ['.gitlab-ci.yml'] },
         { name: 'bower', fileNames: ['.bowerrc', 'bower.json'] },


### PR DESCRIPTION
Self explanatory, it adds [`app.json`](https://devcenter.heroku.com/articles/app-json-schema) as part of the Heroku files.

Preview with a [real project](https://github.com/justalemon/MEKAsystems):
![image](https://user-images.githubusercontent.com/11861253/51577730-a47d1080-1e99-11e9-921b-602a4351df6b.png)

Preview with some random files:
![image](https://user-images.githubusercontent.com/11861253/51577740-af37a580-1e99-11e9-9b31-4ec349a76af6.png)
