### PR TITLE
Add web folder icon

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -78,7 +78,7 @@ export const folderIcons: FolderTheme[] = [
             { name: 'folder-theme', folderNames: ['themes', 'theme', 'color', 'colors', 'design', 'designs'] },
             { name: 'folder-webpack', folderNames: ['webpack', '.webpack'] },
             { name: 'folder-global', folderNames: ['global'] },
-            { name: 'folder-public', folderNames: ['public', 'wwwroot'] },
+            { name: 'folder-public', folderNames: ['public', 'wwwroot', 'web'] },
             { name: 'folder-include', folderNames: ['include', 'includes', '_includes'] },
             { name: 'folder-docker', folderNames: ['docker', 'dockerfiles', '.docker'] },
             { name: 'folder-ngrx-effects', folderNames: ['effects'], enabledFor: [IconPack.Ngrx] },


### PR DESCRIPTION
This is a simple proposal which makes folders named "web" have the "public" icon, as they likely have web-facing files like pages, scripts, and style-sheets, much like the "public" and "wwwroot" folders.