### PR TITLE
Add config for grayscale icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ After installation or update you can click on the 'Activate'-button to activate 
 
 <img src="https://raw.githubusercontent.com/PKief/vscode-material-icon-theme/master/images/oneclickactivation.png" alt="activation" width="60%">
 
-## Grayscale icons
+## Custom icon saturation
 
-If colors do not make you happy you can change icons to grayscale:
+If colors do not make you happy you can change icons to have less saturation making them look grayish or completely grayscale by setting saturation to 0:
 
 ```json
-"material-icon-theme.grayscale": true
+"material-icon-theme.saturation": 0.5
 ```
 
 ## Commands
@@ -126,7 +126,9 @@ Press `Ctrl-Shift-P` to open the command palette and type `Material Icons`.
 
 - **Restore Default Configuration**: Reset the default configurations of the icon theme.
 
-- **Toggle Grayscale**: Change icons to grayscale.
+- **Toggle Grayscale**: Change icons to saturation to 0 making them look grayscale.
+
+- **Change Saturation**: Change the saturation value of the icons.
 
 ## Icon sources
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ After installation or update you can click on the 'Activate'-button to activate 
 
 <img src="https://raw.githubusercontent.com/PKief/vscode-material-icon-theme/master/images/oneclickactivation.png" alt="activation" width="60%">
 
+## Grayscale icons
+
+If colors do not make you happy you can change icons to grayscale:
+
+```json
+"material-icon-theme.grayscale": true
+```
+
 ## Commands
 
 Press `Ctrl-Shift-P` to open the command palette and type `Material Icons`.
@@ -117,6 +125,8 @@ Press `Ctrl-Shift-P` to open the command palette and type `Material Icons`.
 - **Hide Folder Arrows**: Hides the arrows next to the folder icons.
 
 - **Restore Default Configuration**: Reset the default configurations of the icon theme.
+
+- **Toggle Grayscale**: Change icons to grayscale.
 
 ## Icon sources
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,10 @@
       {
         "command": "material-icon-theme.grayscale",
         "title": "%command.grayscale%"
+      },
+      {
+        "command": "material-icon-theme.saturation",
+        "title": "%command.saturation%"
       }
     ],
     "configuration": {
@@ -162,10 +166,12 @@
           "default": false,
           "description": "%configuration.hidesExplorerArrows%"
         },
-        "material-icon-theme.grayscale": {
-          "type": "boolean",
-          "default": false,
-          "description": "%configuration.grayscale%"
+        "material-icon-theme.saturation": {
+          "type": "number",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 1,
+          "description": "%configuration.saturation%"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,10 @@
       {
         "command": "material-icon-theme.opacity",
         "title": "%command.opacity%"
+      },
+      {
+        "command": "material-icon-theme.grayscale",
+        "title": "%command.grayscale%"
       }
     ],
     "configuration": {
@@ -157,6 +161,11 @@
           "type": "boolean",
           "default": false,
           "description": "%configuration.hidesExplorerArrows%"
+        },
+        "material-icon-theme.grayscale": {
+          "type": "boolean",
+          "default": false,
+          "description": "%configuration.grayscale%"
         }
       }
     }
@@ -195,3 +204,4 @@
     "vscode": "^1.1.26"
   }
 }
+

--- a/package.nls.json
+++ b/package.nls.json
@@ -6,6 +6,7 @@
     "command.restoreDefaultConfig": "Material Icons: Restore Default Configuration",
     "command.hidesExplorerArrows": "Material Icons: Hide Folder Arrows",
     "command.opacity": "Material Icons: Change Opacity",
+    "command.grayscale": "Material Icons: Toggle Grayscale",
     "configuration.title": "Material Icons",
     "configuration.files.associations": "Set custom file icon associations.",
     "configuration.folders.associations": "Set custom folder icon associations.",
@@ -25,5 +26,6 @@
     "configuration.folders.theme.none": "No folder icons.",
     "configuration.folders.color": "Change the color of the folder icons.",
     "configuration.hidesExplorerArrows": "Hide explorer arrows before folder.",
-    "configuration.opacity": "Change the opacity of the icons."
+    "configuration.opacity": "Change the opacity of the icons.",
+    "configuration.grayscale": "Enable grayscale icons."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -7,6 +7,7 @@
     "command.hidesExplorerArrows": "Material Icons: Hide Folder Arrows",
     "command.opacity": "Material Icons: Change Opacity",
     "command.grayscale": "Material Icons: Toggle Grayscale",
+    "command.saturation": "Material Icons: Change Saturation",
     "configuration.title": "Material Icons",
     "configuration.files.associations": "Set custom file icon associations.",
     "configuration.folders.associations": "Set custom folder icon associations.",
@@ -27,5 +28,5 @@
     "configuration.folders.color": "Change the color of the folder icons.",
     "configuration.hidesExplorerArrows": "Hide explorer arrows before folder.",
     "configuration.opacity": "Change the opacity of the icons.",
-    "configuration.grayscale": "Enable grayscale icons."
+    "configuration.saturation": "Change the saturation of the icons."
 }

--- a/src/commands/grayscale.ts
+++ b/src/commands/grayscale.ts
@@ -1,0 +1,53 @@
+import * as vscode from 'vscode';
+import * as helpers from './../helpers';
+import * as i18n from './../i18n';
+
+/** Command to toggle grayscale. */
+export const toggleGrayscale = () => {
+    return checkGrayscaleStatus()
+        .then(showQuickPickItems)
+        .then(handleQuickPickActions)
+        .catch(err => console.log(err));
+};
+
+/** Show QuickPick items to select preferred configuration for grayscale icons. */
+const showQuickPickItems = (status: boolean) => {
+    const on: vscode.QuickPickItem = {
+        description: i18n.translate('toggleSwitch.on'),
+        detail: i18n.translate(`grayscale.enableGrayscale`),
+        label: status ? '\u2714' : '\u25FB'
+    };
+    const off: vscode.QuickPickItem = {
+        description: i18n.translate('toggleSwitch.off'),
+        detail: i18n.translate(`grayscale.disableGrayscale`),
+        label: !status ? '\u2714' : '\u25FB'
+    };
+    return vscode.window.showQuickPick(
+        [on, off], {
+            placeHolder: i18n.translate('grayscale.toggleGrayscale'),
+            ignoreFocusOut: false,
+            matchOnDescription: true
+        });
+};
+
+/** Handle the actions from the QuickPick. */
+const handleQuickPickActions = (value: vscode.QuickPickItem) => {
+    if (!value || !value.description) return;
+    switch (value.description) {
+        case i18n.translate('toggleSwitch.on'): {
+            helpers.setThemeConfig('grayscale', true, true);
+            break;
+        }
+        case i18n.translate('toggleSwitch.off'): {
+            helpers.setThemeConfig('grayscale', false, true);
+            break;
+        }
+        default:
+            break;
+    }
+};
+
+/** Is grayscale icons enabled? */
+export const checkGrayscaleStatus = (): Promise<boolean> => {
+    return helpers.getMaterialIconsJSON().then((config) => config.options.grayscale);
+};

--- a/src/commands/grayscale.ts
+++ b/src/commands/grayscale.ts
@@ -35,11 +35,11 @@ const handleQuickPickActions = (value: vscode.QuickPickItem) => {
     if (!value || !value.description) return;
     switch (value.description) {
         case i18n.translate('toggleSwitch.on'): {
-            helpers.setThemeConfig('grayscale', true, true);
+            helpers.setThemeConfig('saturation', 0, true);
             break;
         }
         case i18n.translate('toggleSwitch.off'): {
-            helpers.setThemeConfig('grayscale', false, true);
+            helpers.setThemeConfig('saturation', 1, true);
             break;
         }
         default:
@@ -49,5 +49,5 @@ const handleQuickPickActions = (value: vscode.QuickPickItem) => {
 
 /** Is grayscale icons enabled? */
 export const checkGrayscaleStatus = (): Promise<boolean> => {
-    return helpers.getMaterialIconsJSON().then((config) => config.options.grayscale);
+    return helpers.getMaterialIconsJSON().then((config) => config.options.saturation === 0);
 };

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -7,6 +7,7 @@ import { toggleIconPacks } from './iconPacks';
 import { changeOpacity } from './opacity';
 import { restoreDefaultConfig } from './restoreConfig';
 import { toggleGrayscale } from './grayscale';
+import { changeSaturation } from './saturation';
 
 // Activate theme
 const activateThemeCommand = vscode.commands.registerCommand('material-icon-theme.activateIcons', () => {
@@ -48,6 +49,11 @@ const grayscaleCommand = vscode.commands.registerCommand('material-icon-theme.gr
     toggleGrayscale();
 });
 
+// Change the saturation of the icons
+const changeSaturationCommand = vscode.commands.registerCommand('material-icon-theme.saturation', () => {
+    changeSaturation();
+});
+
 export const commands = [
     activateThemeCommand,
     toggleIconPacksCommand,
@@ -56,5 +62,6 @@ export const commands = [
     restoreDefaultConfigCommand,
     hidesExplorerArrowsCommand,
     changeOpacityCommand,
-    grayscaleCommand
+    grayscaleCommand,
+    changeSaturationCommand
 ];

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -6,6 +6,7 @@ import { changeFolderTheme } from './folders';
 import { toggleIconPacks } from './iconPacks';
 import { changeOpacity } from './opacity';
 import { restoreDefaultConfig } from './restoreConfig';
+import { toggleGrayscale } from './grayscale';
 
 // Activate theme
 const activateThemeCommand = vscode.commands.registerCommand('material-icon-theme.activateIcons', () => {
@@ -42,6 +43,11 @@ const changeOpacityCommand = vscode.commands.registerCommand('material-icon-them
     changeOpacity();
 });
 
+// Toggle grayscale icons
+const grayscaleCommand = vscode.commands.registerCommand('material-icon-theme.grayscale', () => {
+    toggleGrayscale();
+});
+
 export const commands = [
     activateThemeCommand,
     toggleIconPacksCommand,
@@ -49,5 +55,6 @@ export const commands = [
     toggleFolderColorCommand,
     restoreDefaultConfigCommand,
     hidesExplorerArrowsCommand,
-    changeOpacityCommand
+    changeOpacityCommand,
+    grayscaleCommand
 ];

--- a/src/commands/restoreConfig.ts
+++ b/src/commands/restoreConfig.ts
@@ -7,6 +7,7 @@ export const restoreDefaultConfig = () => {
     helpers.setThemeConfig('folders.color', undefined, true);
     helpers.setThemeConfig('hidesExplorerArrows', undefined, true);
     helpers.setThemeConfig('opacity', undefined, true);
+    helpers.setThemeConfig('grayscale', undefined, true);
     helpers.setThemeConfig('files.associations', undefined, true);
     helpers.setThemeConfig('folders.associations', undefined, true);
     helpers.setThemeConfig('languages.associations', undefined, true);

--- a/src/commands/restoreConfig.ts
+++ b/src/commands/restoreConfig.ts
@@ -7,7 +7,7 @@ export const restoreDefaultConfig = () => {
     helpers.setThemeConfig('folders.color', undefined, true);
     helpers.setThemeConfig('hidesExplorerArrows', undefined, true);
     helpers.setThemeConfig('opacity', undefined, true);
-    helpers.setThemeConfig('grayscale', undefined, true);
+    helpers.setThemeConfig('saturation', undefined, true);
     helpers.setThemeConfig('files.associations', undefined, true);
     helpers.setThemeConfig('folders.associations', undefined, true);
     helpers.setThemeConfig('languages.associations', undefined, true);

--- a/src/commands/saturation.ts
+++ b/src/commands/saturation.ts
@@ -1,0 +1,43 @@
+import * as vscode from 'vscode';
+import { getDefaultIconOptions, validateSaturationValue } from '../icons';
+import * as helpers from './../helpers';
+import * as i18n from './../i18n';
+
+/** Command to toggle the folder icons. */
+export const changeSaturation = () => {
+    return getCurrentSaturationValue()
+        .then(showInput)
+        .catch(err => console.log(err));
+};
+
+/** Show input to enter the saturation value. */
+const showInput = (saturation: number) => {
+    vscode.window.showInputBox({
+        placeHolder: i18n.translate('saturation.inputPlaceholder'),
+        ignoreFocusOut: true,
+        value: String(saturation),
+        validateInput: validateSaturationInput
+    }).then(value => setSaturationConfig(+value));
+};
+
+/** Validate the saturation value which was inserted by the user. */
+const validateSaturationInput = (saturationInput: string) => {
+    if (!validateSaturationValue(+saturationInput)) {
+        return i18n.translate('saturation.wrongValue');
+    }
+    return undefined;
+};
+
+/** Get the current value of the saturation of the icons. */
+export const getCurrentSaturationValue = (): Promise<number> => {
+    const defaultOptions = getDefaultIconOptions();
+    return helpers.getMaterialIconsJSON().then((config) =>
+        config.options.saturation === undefined ?
+            defaultOptions.saturation : config.options.saturation);
+};
+
+const setSaturationConfig = (saturation: number) => {
+    if (saturation !== undefined) {
+        helpers.setThemeConfig('saturation', saturation, true);
+    }
+};

--- a/src/i18n/lang-en.ts
+++ b/src/i18n/lang-en.ts
@@ -44,5 +44,9 @@ export const translation: Translation = {
         'toggleGrayscale': 'Toggle grayscale icons',
         'enableGrayscale': 'Enable grayscale icons',
         'disableGrayscale': 'Disable grayscale icons'
+    },
+    'saturation': {
+        'inputPlaceholder': 'Saturation value (between 0 and 1)',
+        'wrongValue': 'The value must be between 0 and 1!',
     }
 };

--- a/src/i18n/lang-en.ts
+++ b/src/i18n/lang-en.ts
@@ -39,5 +39,10 @@ export const translation: Translation = {
     'confirmReload': 'You have to restart VS Code to activate the changes to the icons.',
     'reload': 'Restart',
     'outdatedVersion': 'You have to update VS Code to use this command.',
-    'updateVSCode': 'Update VS Code'
+    'updateVSCode': 'Update VS Code',
+    'grayscale': {
+        'toggleGrayscale': 'Toggle grayscale icons',
+        'enableGrayscale': 'Enable grayscale icons',
+        'disableGrayscale': 'Disable grayscale icons'
+    }
 };

--- a/src/icons/generator/iconGrayscale.ts
+++ b/src/icons/generator/iconGrayscale.ts
@@ -1,0 +1,119 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Changes all icons in the set to grayscale.
+ * @param fileNames Only change the grayscale of certain file names.
+ */
+export const setIconGrayscale = (enable: boolean, fileNames?: string[]) => {
+
+    return new Promise((resolve, reject) => {
+        let iconsPath = path.join(__dirname, '..', '..', '..');
+        const parentFolder = iconsPath.split(path.sep).pop();
+        if (parentFolder === 'out') {
+            iconsPath = path.join(iconsPath, '..');
+        }
+        iconsPath = path.join(iconsPath, 'icons');
+
+        // read all icon files from the icons folder
+        try {
+            (fileNames || fs.readdirSync(iconsPath)).forEach(iconFileName => {
+                const svgFilePath = path.join(iconsPath, iconFileName);
+
+                // Read SVG file
+                const svg = fs.readFileSync(svgFilePath, 'utf-8');
+
+                // Get the root element of the SVG file
+                const svgRootElement = getSVGRootElement(svg);
+                if (!svgRootElement) return;
+
+                let updatedRootElement: string;
+                if (enable) {
+                    updatedRootElement = addFilterAttribute(svgRootElement);
+                } else {
+                    updatedRootElement = removeFilterAttribute(svgRootElement);
+                }
+                let updatedSVG = svg.replace(/<svg[^>]*>/, updatedRootElement);
+                if (enable) {
+                    updatedSVG = addFilterElement(updatedSVG);
+                } else {
+                    updatedSVG = removeFilterElement(updatedSVG);
+                }
+
+                fs.writeFileSync(svgFilePath, updatedSVG);
+                resolve();
+            });
+        }
+        catch (e) {
+            console.log(e);
+            reject(e);
+        }
+        resolve();
+    });
+};
+
+/**
+ * Get the SVG root element.
+ * @param svg SVG file as string.
+ */
+const getSVGRootElement = (svg: string) => {
+    const result = new RegExp(/<svg[^>]*>/).exec(svg);
+    if (result.length > 0) {
+        return result[0];
+    } else {
+        return undefined;
+    }
+};
+
+/**
+ * Add an filter attribute to the SVG icon.
+ * @param svgRoot Root element of the SVG icon.
+ */
+const addFilterAttribute = (svgRoot: string) => {
+    const pattern = new RegExp(/\sfilter="[^"]+?"/);
+    const filter = 'url(#grayscale)';
+    // if the filter attribute already exists
+    if (pattern.test(svgRoot)) {
+        return svgRoot.replace(pattern, ` filter="${filter}"`);
+    } else {
+        return svgRoot.replace(/^<svg/, `<svg filter="${filter}"`);
+    }
+};
+
+/**
+ * Remove the filter attribute of the SVG icon.
+ * @param svgRoot Root element of the SVG icon.
+ */
+const removeFilterAttribute = (svgRoot: string) => {
+    const pattern = new RegExp(/\sfilter="[^"]+?"/);
+    // check if the filter attribute exists
+    if (pattern.test(svgRoot)) {
+        return svgRoot.replace(pattern, '');
+    }
+    return svgRoot;
+};
+
+/**
+ * Add filter element to the SVG icon.
+ * @param svg SVG file as string.
+ */
+const addFilterElement = (svg: string) => {
+    const pattern = new RegExp(/<filter id="grayscale".+<\/filter>.*<\/svg>/);
+    if (!pattern.test(svg)) {
+        const filterElement = `<filter id="grayscale"><feColorMatrix type="saturate" values="0"/></filter>`;
+        return svg.replace(/<\/svg>/, `${filterElement}</svg>`);
+    }
+    return svg;
+};
+
+/**
+ * Remove filter element from the SVG icon.
+ * @param svg SVG file as string.
+ */
+const removeFilterElement = (svg: string) => {
+    const pattern = new RegExp(/<filter id="grayscale".+<\/filter>(.*<\/svg>)/);
+    if (pattern.test(svg)) {
+        return svg.replace(pattern, `$1`);
+    }
+    return svg;
+};

--- a/src/icons/generator/index.ts
+++ b/src/icons/generator/index.ts
@@ -4,3 +4,4 @@ export * from './languageGenerator';
 export * from './constants';
 export * from './jsonGenerator';
 export * from './iconOpacity';
+export * from './iconGrayscale';

--- a/src/icons/generator/index.ts
+++ b/src/icons/generator/index.ts
@@ -4,4 +4,4 @@ export * from './languageGenerator';
 export * from './constants';
 export * from './jsonGenerator';
 export * from './iconOpacity';
-export * from './iconGrayscale';
+export * from './iconSaturation';

--- a/src/icons/generator/jsonGenerator.ts
+++ b/src/icons/generator/jsonGenerator.ts
@@ -6,7 +6,7 @@ import { fileIcons } from '../fileIcons';
 import { folderIcons } from '../folderIcons';
 import { languageIcons } from '../languageIcons';
 import { iconJsonName } from './constants';
-import { generateFolderIcons, getFileIconDefinitions, getFolderIconDefinitions, getLanguageIconDefinitions, setIconOpacity, validateHEXColorCode, validateOpacityValue } from './index';
+import { generateFolderIcons, getFileIconDefinitions, getFolderIconDefinitions, getLanguageIconDefinitions, setIconOpacity, setIconGrayscale, validateHEXColorCode, validateOpacityValue } from './index';
 
 /**
  * Generate the complete icon configuration object that can be written as JSON file.
@@ -60,6 +60,9 @@ export const createIconFile = async (updatedConfigs?: IconJsonOptions, updatedJS
             }
             if (!updatedConfigs || updatedConfigs.opacity !== undefined) {
                 await setIconOpacity(options.opacity);
+            }
+            if (!updatedConfigs || updatedConfigs.grayscale !== undefined) {
+                await setIconGrayscale(options.grayscale);
             }
         });
     } catch (error) {

--- a/src/icons/generator/jsonGenerator.ts
+++ b/src/icons/generator/jsonGenerator.ts
@@ -6,7 +6,7 @@ import { fileIcons } from '../fileIcons';
 import { folderIcons } from '../folderIcons';
 import { languageIcons } from '../languageIcons';
 import { iconJsonName } from './constants';
-import { generateFolderIcons, getFileIconDefinitions, getFolderIconDefinitions, getLanguageIconDefinitions, setIconOpacity, setIconGrayscale, validateHEXColorCode, validateOpacityValue } from './index';
+import { generateFolderIcons, getFileIconDefinitions, getFolderIconDefinitions, getLanguageIconDefinitions, setIconOpacity, setIconSaturation, validateHEXColorCode, validateOpacityValue, validateSaturationValue } from './index';
 
 /**
  * Generate the complete icon configuration object that can be written as JSON file.
@@ -32,9 +32,14 @@ export const createIconFile = async (updatedConfigs?: IconJsonOptions, updatedJS
     const iconJSONPath = path.join(__dirname, '../../../', 'src', iconJsonName);
     const json = generateIconConfigurationObject(options);
 
-    // make sure that the opacity value must be entered correctly to trigger a reload.
-    if (updatedConfigs && updatedConfigs.opacity !== undefined && !validateOpacityValue(updatedConfigs.opacity)) {
-        return Promise.reject('Material Icons: Invalid opacity value!');
+    // make sure that the opacity and saturation values must be entered correctly to trigger a reload.
+    if (updatedConfigs) {
+        if (updatedConfigs.opacity !== undefined && !validateOpacityValue(updatedConfigs.opacity)) {
+            return Promise.reject('Material Icons: Invalid opacity value!');
+        }
+        if (updatedConfigs.saturation !== undefined && !validateSaturationValue(updatedConfigs.saturation)) {
+            return Promise.reject('Material Icons: Invalid saturation value!');
+        }
     }
 
     // make sure that the value for the folder color is entered correctly to trigger a reload.
@@ -61,8 +66,8 @@ export const createIconFile = async (updatedConfigs?: IconJsonOptions, updatedJS
             if (!updatedConfigs || updatedConfigs.opacity !== undefined) {
                 await setIconOpacity(options.opacity);
             }
-            if (!updatedConfigs || updatedConfigs.grayscale !== undefined) {
-                await setIconGrayscale(options.grayscale);
+            if (!updatedConfigs || updatedConfigs.saturation !== undefined) {
+                await setIconSaturation(options.saturation);
             }
         });
     } catch (error) {
@@ -83,6 +88,7 @@ export const getDefaultIconOptions = (): IconJsonOptions => ({
     activeIconPack: 'angular',
     hidesExplorerArrows: false,
     opacity: 1,
+    saturation: 1,
     files: { associations: {} },
     languages: { associations: {} },
 });

--- a/src/models/i18n/translation.ts
+++ b/src/models/i18n/translation.ts
@@ -38,4 +38,9 @@ export interface Translation {
     reload?: string;
     outdatedVersion?: string;
     updateVSCode?: string;
+    grayscale?: {
+        toggleGrayscale?: string;
+        enableGrayscale?: string;
+        disableGrayscale?: string;
+    };
 }

--- a/src/models/i18n/translation.ts
+++ b/src/models/i18n/translation.ts
@@ -43,4 +43,8 @@ export interface Translation {
         enableGrayscale?: string;
         disableGrayscale?: string;
     };
+    saturation?: {
+        inputPlaceholder?: string;
+        wrongValue?: string;
+    };
 }

--- a/src/models/icons/iconJsonOptions.ts
+++ b/src/models/icons/iconJsonOptions.ts
@@ -2,7 +2,7 @@ export interface IconJsonOptions {
     activeIconPack?: string;
     hidesExplorerArrows?: boolean;
     opacity?: number;
-    grayscale?: boolean;
+    saturation?: number;
     folders?: {
         theme?: string;
         color?: string;

--- a/src/models/icons/iconJsonOptions.ts
+++ b/src/models/icons/iconJsonOptions.ts
@@ -2,6 +2,7 @@ export interface IconJsonOptions {
     activeIconPack?: string;
     hidesExplorerArrows?: boolean;
     opacity?: number;
+    grayscale?: boolean;
     folders?: {
         theme?: string;
         color?: string;


### PR DESCRIPTION
Hi, I'm not a big fan of colored icons as I think they draw too much attention, however, I do like having different symbols for each file type.

Inspired by the awesome hack used to change the icons opacity I added a new command and configuration to allow switching all icons to grayscale. This is done by adding an SVG filter to each icon file changing its saturation to 0.

Here is an example of how it looks: (I loved it!)
<img width="400" src="https://user-images.githubusercontent.com/11041/52429150-9dd1d880-2aea-11e9-81c0-95e878902b9b.png">
