### PR TITLE
Use clojure icon for .cljc files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Choose your icon colors from the [material design colors](https://material.googl
 ### Use icons from here
 - [Material Design Icons](https://materialdesignicons.com/)
     - download them as SVG and edit the icons e.g. with Inkscape
-- you can use any other source **as long as the icons are free to use!**. This icon theme is absolutely non-commercial, but you should always check the license of your sources! 
+- you can use any other source **as long as the icons are free to use!** This icon theme is absolutely non-commercial, but you should always check the license of your sources! 
 
 ## Add translations
 - Create or edit the translations in the `src/i18n` directory.

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -364,7 +364,7 @@ export const fileIcons: FileIcons = {
             ]
         },
         { name: 'lua', fileExtensions: ['lua'], fileNames: ['.luacheckrc'] },
-        { name: 'clojure', fileExtensions: ['clj', 'cljs'] },
+        { name: 'clojure', fileExtensions: ['clj', 'cljs', 'cljc'] },
         { name: 'groovy', fileExtensions: ['groovy'] },
         { name: 'r', fileExtensions: ['r', 'rmd'], fileNames: ['.Rhistory'] },
         { name: 'dart', fileExtensions: ['dart'] },


### PR DESCRIPTION
`.cljc` files are used with [reader conditionals](https://clojure.org/guides/reader_conditionals).

**Bonus:** removed unnecessary dot from contributing instructions