### PR TITLE
feat: Add `.cson` and `.iced` CoffeeScript extensions

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -342,7 +342,7 @@ export const fileIcons: FileIcons = {
         { name: 'virtual', fileExtensions: ['vdi', 'vbox', 'vbox-prev'] },
         { name: 'email', fileExtensions: ['ics'], fileNames: ['.mailmap'] },
         { name: 'audio', fileExtensions: ['mp3', 'flac', 'm4a', 'wma', 'aiff'] },
-        { name: 'coffee', fileExtensions: ['coffee'] },
+        { name: 'coffee', fileExtensions: ['coffee', 'cson', 'iced'] },
         { name: 'document', fileExtensions: ['txt'] },
         { name: 'graphql', fileExtensions: ['graphql', 'gql'], fileNames: ['.graphqlconfig'] },
         { name: 'rust', fileExtensions: ['rs'] },


### PR DESCRIPTION
This adds support for the [`.cson`](https://github.com/bevry/cson) and the [`.iced` CoffeeScript](http://maxtaco.github.io/coffee-script/) file extensions, which are now both supported by **VS Code** as of https://github.com/Microsoft/vscode/pull/70686.