### PR TITLE
Added angular default route names

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -104,7 +104,14 @@ export const fileIcons: FileIcons = {
         {
             name: 'routing',
             fileExtensions: ['routing.ts', 'routing.js', 'routes.ts', 'routes.js'],
-            fileNames: ['router.js', 'router.ts', 'routes.js', 'routes.ts'],
+            fileNames: [
+                'router.js',
+                'router.ts',
+                'routes.js',
+                'routes.ts',
+                'app-routing.module.ts',
+                'app-routing.module.tns.ts'
+            ],
             enabledFor: [IconPack.Angular, IconPack.Ngrx, IconPack.React, IconPack.Redux, IconPack.Vue, IconPack.Vuex]
         },
         {


### PR DESCRIPTION
Hi! Love Material Icon Theme, I figured it should also add the routes icon to the app route filenames that are autogenerated by angular cli angular projects (as well as shared nativescript projects).

I've tested my code as per the [update api](https://github.com/PKief/vscode-material-icon-theme/blob/master/CONTRIBUTING.md#update-api) section - here's an screengrab of my changes when I launched the extension in the debug window:

<img width="425" alt="Capture" src="https://user-images.githubusercontent.com/4802954/56866466-5e23da00-69d1-11e9-9555-9fcae6c52fdd.PNG">

Hope that's all OK!