### PR TITLE
Add icons for Brotli

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -190,8 +190,10 @@ export const fileIcons: FileIcons = {
                 'tar',
                 'gz',
                 'xz',
+                'br',
                 'bzip2',
                 'gzip',
+                'brotli',
                 '7z',
                 'rar',
                 'tgz'


### PR DESCRIPTION
Brotli is Google's next-generation compression standard, supported by most major web browsers. I've added `.br` files to the pre-existing default 'zip' icon. We could also use the actual Brotli icon seen on https://brotli.org/:

![image](https://user-images.githubusercontent.com/8939680/58814471-6633f280-85eb-11e9-9e29-14625d1c319e.png)
