### PR TITLE
NestJS Icons - add main Filetypes to NestJS

### DIFF
--- a/icons/nest-blue.svg
+++ b/icons/nest-blue.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="300px" height="300px" viewBox="0 0 300 300" style="enable-background:new 0 0 300 300;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#E0234E;}
+	.st0{fill:#0288D1;}
 </style>
 <g transform="translate(-25.4 -196.99)">
 	<path class="st0" d="M201.6,200.1c-2.1,0-4.1,0.5-5.9,1.1c3.9,2.6,6,6,7.1,9.9c0.1,0.5,0.2,0.9,0.3,1.4c0.1,0.5,0.2,0.9,0.2,1.4

--- a/icons/nest-darkgreen.svg
+++ b/icons/nest-darkgreen.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="300px" height="300px" viewBox="0 0 300 300" style="enable-background:new 0 0 300 300;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#E0234E;}
+	.st0{fill:#00897B;}
 </style>
 <g transform="translate(-25.4 -196.99)">
 	<path class="st0" d="M201.6,200.1c-2.1,0-4.1,0.5-5.9,1.1c3.9,2.6,6,6,7.1,9.9c0.1,0.5,0.2,0.9,0.3,1.4c0.1,0.5,0.2,0.9,0.2,1.4

--- a/icons/nest-green.svg
+++ b/icons/nest-green.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="300px" height="300px" viewBox="0 0 300 300" style="enable-background:new 0 0 300 300;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#E0234E;}
+	.st0{fill:#43A047;}
 </style>
 <g transform="translate(-25.4 -196.99)">
 	<path class="st0" d="M201.6,200.1c-2.1,0-4.1,0.5-5.9,1.1c3.9,2.6,6,6,7.1,9.9c0.1,0.5,0.2,0.9,0.3,1.4c0.1,0.5,0.2,0.9,0.2,1.4

--- a/icons/nest-purple.svg
+++ b/icons/nest-purple.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="300px" height="300px" viewBox="0 0 300 300" style="enable-background:new 0 0 300 300;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#E0234E;}
+	.st0{fill:#AB47BC;}
 </style>
 <g transform="translate(-25.4 -196.99)">
 	<path class="st0" d="M201.6,200.1c-2.1,0-4.1,0.5-5.9,1.1c3.9,2.6,6,6,7.1,9.9c0.1,0.5,0.2,0.9,0.3,1.4c0.1,0.5,0.2,0.9,0.2,1.4

--- a/icons/nest-red.svg
+++ b/icons/nest-red.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="300px" height="300px" viewBox="0 0 300 300" style="enable-background:new 0 0 300 300;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#E0234E;}
+	.st0{fill:#E53935;}
 </style>
 <g transform="translate(-25.4 -196.99)">
 	<path class="st0" d="M201.6,200.1c-2.1,0-4.1,0.5-5.9,1.1c3.9,2.6,6,6,7.1,9.9c0.1,0.5,0.2,0.9,0.3,1.4c0.1,0.5,0.2,0.9,0.2,1.4

--- a/icons/nest-yellow.svg
+++ b/icons/nest-yellow.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="300px" height="300px" viewBox="0 0 300 300" style="enable-background:new 0 0 300 300;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#E0234E;}
+	.st0{fill:#FFCA28;}
 </style>
 <g transform="translate(-25.4 -196.99)">
 	<path class="st0" d="M201.6,200.1c-2.1,0-4.1,0.5-5.9,1.1c3.9,2.6,6,6,7.1,9.9c0.1,0.5,0.2,0.9,0.3,1.4c0.1,0.5,0.2,0.9,0.2,1.4

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
             "%configuration.activeIconPack.react_redux%",
             "%configuration.activeIconPack.vue%",
             "%configuration.activeIconPack.vue_vuex%",
+            "%configuration.activeIconPack.nest%",
             "%configuration.activeIconPack.none%"
           ],
           "enum": [
@@ -121,6 +122,7 @@
             "react_redux",
             "vue",
             "vue_vuex",
+            "nest",
             "none"
           ]
         },

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -22,6 +22,7 @@
     "configuration.activeIconPack.react_redux": "Icons für React und Redux",
     "configuration.activeIconPack.vue": "Icons für Vue.",
     "configuration.activeIconPack.vue_vuex": "Icons für Vue und Vuex.",
+    "configuration.activeIconPack.nest": "Icons für NestJS.",
     "configuration.activeIconPack.none": "Kein Icon-Pack aktiviert.",
     "configuration.folders.theme": "Art der Ordner Icons auswählen.",
     "configuration.folders.theme.specific": "Spezifische Ordner Icons auswählen.",

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -20,6 +20,7 @@
     "configuration.activeIconPack.react_redux": "Iconos de React y Redux.",
     "configuration.activeIconPack.vue": "Iconos de Vue.",
     "configuration.activeIconPack.vue_vuex": "Iconos de Vue y Vuex.",
+    "configuration.activeIconPack.nest": "Iconos de NestJS.",
     "configuration.activeIconPack.none": "No hay ningún paquete de iconos activo.",
     "configuration.folders.theme": "Seleccione el tipo de iconos de carpeta.",
     "configuration.folders.theme.specific": "Seleccione iconos de carpeta específicos.",

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -20,6 +20,7 @@
     "configuration.activeIconPack.react_redux": "Icônes pour React et Redux.",
     "configuration.activeIconPack.vue": "Icônes pour Vue.",
     "configuration.activeIconPack.vue_vuex": "Icônes pour Vue et Vuex.",
+    "configuration.activeIconPack.nest": "Icônes pour NestJS.",
     "configuration.activeIconPack.none": "Aucun pack d'icônes n'est actif.",
     "configuration.folders.theme": "Sélectionner le type d'icônes de dossier.",
     "configuration.folders.theme.specific": "Sélectionner des icônes de dossiers spécifiques.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -22,6 +22,7 @@
     "configuration.activeIconPack.react_redux": "Icons for React and Redux.",
     "configuration.activeIconPack.vue": "Icons for Vue.",
     "configuration.activeIconPack.vue_vuex": "Icons for Vue and Vuex.",
+    "configuration.activeIconPack.nest": "Icons for NestJS.",
     "configuration.activeIconPack.none": "No icon pack enabled.",
     "configuration.folders.theme": "Set the type for the folder icons.",
     "configuration.folders.theme.specific": "Select specific folder icons.",

--- a/package.nls.nl.json
+++ b/package.nls.nl.json
@@ -22,6 +22,7 @@
     "configuration.activeIconPack.react_redux": "Icons for React en Redux.",
     "configuration.activeIconPack.vue": "Icons voor Vue.",
     "configuration.activeIconPack.vue_vuex": "Icons voor Vue en Vuex.",
+    "configuration.activeIconPack.nest": "Icons voor NestJS.",
     "configuration.activeIconPack.none": "Geen iconpakket ingeschakeld.",
     "configuration.folders.theme": "Kies het type foldericons.",
     "configuration.folders.theme.specific": "Selecteer bepaalde foldericons.",

--- a/package.nls.pl.json
+++ b/package.nls.pl.json
@@ -22,6 +22,7 @@
     "configuration.activeIconPack.react_redux": "Ikony dla Reacta i Reduxa.",
     "configuration.activeIconPack.vue": "Ikony dla Vue.",
     "configuration.activeIconPack.vue_vuex": "Ikony dla Vue i Vuex.",
+    "configuration.activeIconPack.nest": "Ikony dla NestJS.",
     "configuration.activeIconPack.none": "Brak włączonej paczki ikon.",
     "configuration.folders.theme": "Wybierz typ ikon folderów.",
     "configuration.folders.theme.specific": "Wybierz ikony folderów.",

--- a/package.nls.pt-BR.json
+++ b/package.nls.pt-BR.json
@@ -20,6 +20,7 @@
     "configuration.activeIconPack.react_redux": "Ícones para React e ngrx.",
     "configuration.activeIconPack.vue": "Ícones para Vue.",
     "configuration.activeIconPack.vue_vuex": "Ícones para Vue e Vuex.",
+    "configuration.activeIconPack.nest": "Ícones para NestJS.",
     "configuration.activeIconPack.none": "Nenhum pacote de ícones ativado.",
     "configuration.folders.theme": "Definir o tipo dos ícones das pastas.",
     "configuration.folders.theme.specific": "Selecione ícones de pastas específicas.",

--- a/package.nls.pt-PT.json
+++ b/package.nls.pt-PT.json
@@ -20,6 +20,7 @@
     "configuration.activeIconPack.react_redux": "Ícones para React e ngrx.",
     "configuration.activeIconPack.vue": "Ícones para Vue.",
     "configuration.activeIconPack.vue_vuex": "Ícones para Vue e Vuex.",
+    "configuration.activeIconPack.nest": "Ícones para NestJS.",
     "configuration.activeIconPack.none": "Nenhum pacote de ícones ativado.",
     "configuration.folders.theme": "Definir o formato dos ícones dos directórios.",
     "configuration.folders.theme.specific": "Selecciona ícones de pastas específicas.",

--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -20,6 +20,7 @@
     "configuration.activeIconPack.react_redux": "Иконки для React и Redux.",
     "configuration.activeIconPack.vue": "Иконки для Vue.",
     "configuration.activeIconPack.vue_vuex": "Иконки для Vue и Vuex.",
+    "configuration.activeIconPack.nest": "Иконки для NestJS.",
     "configuration.activeIconPack.none": "Папка с иконками не включена.",
     "configuration.folders.theme": "Установить тип иконок для папок.",
     "configuration.folders.theme.specific": "Выберите конкретные значки папок.",

--- a/package.nls.zh-CN.json
+++ b/package.nls.zh-CN.json
@@ -20,6 +20,7 @@
     "configuration.activeIconPack.react_redux": "React和Redux的图标。",
     "configuration.activeIconPack.vue": "Vue的图标。",
     "configuration.activeIconPack.vue_vuex": "Vue和Vuex的图标。",
+    "configuration.activeIconPack.nest": "NestJS的图标。",
     "configuration.activeIconPack.none": "没有启用图标包。",
     "configuration.folders.theme": "设置文件夹图标的类型。",
     "configuration.folders.theme.specific": "选择特定文件夹图标。",

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -801,6 +801,28 @@ export const fileIcons: FileIcons = {
         { name: 'svelte', fileExtensions: ['svelte'] },
         { name: 'vim', fileExtensions: ['vimrc', 'gvimrc', 'exrc'] },
         { name: 'nest', fileNames: ['nest-cli.json', '.nest-cli.json', 'nestconfig.json', '.nestconfig.json'] },
+        {
+            name: 'nest-blue',
+            fileExtensions: [
+                'dto.ts',
+                'dto.js',
+                'interface.ts',
+                'interface.js',
+                'entity.ts',
+                'entity.js',
+                'model.ts',
+                'model.js',
+                'enum.ts',
+                'enum.js',
+                'repository.ts',
+                'repository.js'],
+            enabledFor: [IconPack.Nest],
+        },
+        { name: 'nest-green', fileExtensions: ['controller.ts', 'controller.js'], enabledFor: [IconPack.Nest] },
+        { name: 'nest-red', fileExtensions: ['module.ts', 'module.js'], enabledFor: [IconPack.Nest] },
+        { name: 'nest-yellow', fileExtensions: ['service.ts', 'service.js'], enabledFor: [IconPack.Nest] },
+        { name: 'nest-purple', fileExtensions: ['decorator.ts', 'decorator.js'], enabledFor: [IconPack.Nest] },
+        { name: 'nest-darkgreen', fileExtensions: ['pipe.ts', 'pipe.js'], enabledFor: [IconPack.Nest] },
         { name: 'moonscript', fileExtensions: ['moon'] },
     ]
 };

--- a/src/models/icons/iconPack.ts
+++ b/src/models/icons/iconPack.ts
@@ -7,5 +7,6 @@ export enum IconPack {
     React = 'react',
     Redux = 'react_redux',
     Vue = 'vue',
-    Vuex = 'vue_vuex'
+    Vuex = 'vue_vuex',
+    Nest = 'nest'
 }


### PR DESCRIPTION
Made essential changes to accommodate [NestJS](https://nestjs.com/) as right now icons of angular type are shown as default as both use same file naming convention, so it was essential to create a new IconType.

Main Changes made:

1. Updates the main NestJS logo color for main files (nest-cli.json, nestconfig.json ...)
2. Persistence Layer file types - blue color (dto, interfaces, entity, model, enum and repository)
3. Module file type - red color
4. Controller file type - green color
5. Service file type - yellow color
6. Decorator file type - purple color
7. Pipe file type - dark green color
8. IconType of Nest
9. Enumeration in package.json
10. Translation in all languages for NestJS entry