### PR TITLE
Create now.json icon

### DIFF
--- a/icons/nowjson.svg
+++ b/icons/nowjson.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M12 1 L 24 23 H 0 z" fill="#000"></path>
+</svg>

--- a/icons/nowjson.svg
+++ b/icons/nowjson.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <path d="M12 1 L 24 23 H 0 z" fill="#000"></path>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 28">
+  <path d="M14 3 L 26 25.75 H 2 z"></path>
 </svg>

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -802,5 +802,6 @@ export const fileIcons: FileIcons = {
         { name: 'vim', fileExtensions: ['vimrc', 'gvimrc', 'exrc'] },
         { name: 'nest', fileNames: ['nest-cli.json', '.nest-cli.json', 'nestconfig.json', '.nestconfig.json'] },
         { name: 'moonscript', fileExtensions: ['moon'] },
+        { name: 'nowjson', fileNames: ['now.json'] },
     ]
 };


### PR DESCRIPTION
[Zeit Now](https://zeit.co/now) is a serverless deployment platform. The configuration is stored in a file called `now.json`.

This will add the Zeit logo to files with this name.