### PR TITLE
Associate "repositories" with database folder icon

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -91,7 +91,7 @@ export const folderIcons: FolderTheme[] = [
             { name: 'folder-redux-actions', folderNames: ['actions'], enabledFor: [IconPack.Redux] },
             { name: 'folder-redux-store', folderNames: ['store'], enabledFor: [IconPack.Redux] },
             { name: 'folder-react-components', folderNames: ['components'], enabledFor: [IconPack.React, IconPack.Redux] },
-            { name: 'folder-database', folderNames: ['db', 'database', 'sql', 'data', '_data', 'repositories'] },
+            { name: 'folder-database', folderNames: ['db', 'database', 'sql', 'data', '_data', 'repository', 'repositories'] },
             { name: 'folder-log', folderNames: ['log', 'logs'] },
             { name: 'folder-temp', folderNames: ['temp', '.temp', 'tmp', '.tmp', 'cached', 'cache', '.cache'] },
             { name: 'folder-aws', folderNames: ['aws', '.aws'] },

--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -91,7 +91,7 @@ export const folderIcons: FolderTheme[] = [
             { name: 'folder-redux-actions', folderNames: ['actions'], enabledFor: [IconPack.Redux] },
             { name: 'folder-redux-store', folderNames: ['store'], enabledFor: [IconPack.Redux] },
             { name: 'folder-react-components', folderNames: ['components'], enabledFor: [IconPack.React, IconPack.Redux] },
-            { name: 'folder-database', folderNames: ['db', 'database', 'sql', 'data', '_data'] },
+            { name: 'folder-database', folderNames: ['db', 'database', 'sql', 'data', '_data', 'repositories'] },
             { name: 'folder-log', folderNames: ['log', 'logs'] },
             { name: 'folder-temp', folderNames: ['temp', '.temp', 'tmp', '.tmp', 'cached', 'cache', '.cache'] },
             { name: 'folder-aws', folderNames: ['aws', '.aws'] },


### PR DESCRIPTION
In projects using the Repository Pattern, we end up with a folder named "repositories" which contains classes which communicate with a data store.

In this pull request, I propose that the database folder icon also be associated with repositories folders.