### PR TITLE
Associate ".expo-shared" with the expo folder icon

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -62,7 +62,7 @@ export const folderIcons: FolderTheme[] = [
                 folderNames: ['view', 'views', 'screen', 'screens', 'page', 'pages', 'html']
             },
             { name: 'folder-vue', folderNames: ['vue'] },
-            { name: 'folder-expo', folderNames: ['.expo'] },
+            { name: 'folder-expo', folderNames: ['.expo', '.expo-shared'] },
             { name: 'folder-config', folderNames: ['config', 'configs', 'configuration', 'configurations', 'settings', '.settings', 'META-INF'] },
             {
                 name: 'folder-i18n',
@@ -178,7 +178,7 @@ export const folderIcons: FolderTheme[] = [
             { name: 'folder-vuex-store', folderNames: ['store'], enabledFor: [IconPack.Vuex] },
             { name: 'folder-nuxt', folderNames: ['nuxt', '.nuxt'], enabledFor: [IconPack.Vuex, IconPack.Vue] },
             { name: 'folder-vue-directives', folderNames: ['directives'], enabledFor: [IconPack.Vuex, IconPack.Vue] },
-            { name: 'folder-vue', folderNames: ['components'], enabledFor: [IconPack.Vuex , IconPack.Vue] },
+            { name: 'folder-vue', folderNames: ['components'], enabledFor: [IconPack.Vuex, IconPack.Vue] },
         ]
     },
     { name: 'classic', defaultIcon: { name: 'folder' }, rootFolder: { name: 'folder-root' } },


### PR DESCRIPTION
Since a little while in Expo React Native projects, the expo-cli has an optimize image feature which create a ".expo-shared" folder to keep track of already optimized assets. Details here: https://blog.expo.io/image-compression-with-expo-cli-d32d15cc8b73

In this pull request, I propose to associate the Expo folder icon to this .expo-shared folder.

Note: I just realized that an additional change slipped in this commit, VSCode removed a stray space before a comma when saving, which I guess is not a bad thing.