### PR TITLE
Add ".env.sample" to the Tune icon

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -614,6 +614,7 @@ export const fileIcons: FileIcons = {
             fileExtensions: ['env'],
             fileNames: [
                 '.env.example',
+                '.env.sample',
                 '.env.local',
                 '.env.dev',
                 '.env.development',


### PR DESCRIPTION
Hi,
.env.sample is often use as an alternative to .env.example, so i propose this change to make it have the Tune icon !
Thanks