### PR TITLE
Add shader icons

### DIFF
--- a/icons/shader-frag.svg
+++ b/icons/shader-frag.svg
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg4"
+   sodipodi:docname="fram_ex.svg"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient919">
+      <stop
+         style="stop-color:#03a9f4;stop-opacity:1;"
+         offset="0"
+         id="stop915" />
+      <stop
+         style="stop-color:#f44336;stop-opacity:1"
+         offset="1"
+         id="stop917" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient911">
+      <stop
+         style="stop-color:#ffc107;stop-opacity:1"
+         offset="0"
+         id="stop907" />
+      <stop
+         style="stop-color:#03a9f4;stop-opacity:1"
+         offset="1"
+         id="stop909" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient897">
+      <stop
+         style="stop-color:#ffc107;stop-opacity:1"
+         offset="0"
+         id="stop893" />
+      <stop
+         style="stop-color:#f44336;stop-opacity:1"
+         offset="1"
+         id="stop895" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient897"
+       id="linearGradient899"
+       x1="6.8493481"
+       y1="16.089991"
+       x2="10.768397"
+       y2="9.0608711"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient911"
+       id="linearGradient913"
+       x1="8.0358496"
+       y1="18.966358"
+       x2="15.999789"
+       y2="18.948381"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient919"
+       id="linearGradient921"
+       x1="17.199152"
+       y1="16.15678"
+       x2="13.055085"
+       y2="8.974576"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2160"
+     inkscape:window-height="1344"
+     id="namedview6"
+     showgrid="false"
+     inkscape:snap-bbox="false"
+     inkscape:bbox-paths="true"
+     inkscape:zoom="27.812867"
+     inkscape:cx="-6.2645711"
+     inkscape:cy="12.96377"
+     inkscape:window-x="0"
+     inkscape:window-y="58"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M 8 20 L 8 18 L 8 16.150391 L 8 16 L 5.7890625 16 L 2 16 L 2 22 L 8 22 L 8 20 z M 4 18 L 6 18 L 6 20 L 4 20 L 4 18 z "
+     id="path881"
+     style="fill:#ffc107;fill-opacity:1" />
+  <path
+     d="M 16 20 L 16 18 L 8 18 L 8 20 L 16 20 z "
+     id="path879"
+     style="fill:url(#linearGradient913);fill-opacity:1" />
+  <path
+     d="M 18.210938 16 L 16 16 L 16 16.150391 L 16 18 L 16 20 L 16 22 L 22 22 L 22 16 L 18.210938 16 z M 18 18 L 20 18 L 20 20 L 18 20 L 18 18 z "
+     id="path877"
+     style="fill:#03a9f4;fill-opacity:1" />
+  <path
+     d="M 12 9 L 9.7304688 9 L 5.7890625 16 L 8 16 L 8 16.150391 L 12 9.0390625 L 12 9 z "
+     id="path891"
+     style="fill:url(#linearGradient899);fill-opacity:1" />
+  <path
+     d="M 12 9 L 12 9.0390625 L 16 16.150391 L 16 16 L 18.210938 16 L 14.269531 9 L 12 9 z "
+     id="path875"
+     style="fill:url(#linearGradient921);fill-opacity:1" />
+  <path
+     d="M 9 3 L 9 9 L 9.7304688 9 L 14.269531 9 L 15 9 L 15 3 L 9 3 z M 11 5 L 13 5 L 13 7 L 11 7 L 11 5 z "
+     id="path2"
+     style="fill:#f44336;fill-opacity:1" />
+</svg>

--- a/icons/shader-geom.svg
+++ b/icons/shader-geom.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg4"
+   sodipodi:docname="geom.svg"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2160"
+     inkscape:window-height="1344"
+     id="namedview6"
+     showgrid="false"
+     inkscape:snap-bbox="false"
+     inkscape:bbox-paths="true"
+     inkscape:zoom="39.333333"
+     inkscape:cx="-9.7743066"
+     inkscape:cy="7.2141824"
+     inkscape:window-x="0"
+     inkscape:window-y="58"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     id="path875"
+     d="m 12,9 v 0.039063 l 4,7.1113285 V 16 h 2.210938 L 14.269531,9 Z m 0,0 H 9.7304688 L 5.7890625,16 H 8 v 0.150391 l 4,-7.1113285 z m 4,11 V 18 H 8 v 2 z"
+     style="fill:#000000;fill-opacity:1" />
+  <path
+     id="path2"
+     style="fill:#ab47bc;fill-opacity:1"
+     d="M 9,3 V 9 H 9.7304688 14.269531 15 V 3 Z m 2,2 h 2 v 2 h -2 z m 7.210938,11 H 16 V 16.150391 18 v 2 2 h 6 V 16 Z M 18,18 h 2 v 2 H 18 Z M 8,20 V 18 16.150391 16 H 5.7890625 2 v 6 H 8 Z M 4,18 h 2 v 2 H 4 Z" />
+</svg>

--- a/icons/shader-vert.svg
+++ b/icons/shader-vert.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg4"
+   sodipodi:docname="vert.svg"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2160"
+     inkscape:window-height="1344"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="19.666667"
+     inkscape:cx="-20.37421"
+     inkscape:cy="4.5514659"
+     inkscape:window-x="0"
+     inkscape:window-y="58"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M 9 3 L 9 9 L 9.7304688 9 L 14.269531 9 L 15 9 L 15 3 L 9 3 z M 11 5 L 13 5 L 13 7 L 11 7 L 11 5 z M 2 16 L 2 22 L 8 22 L 8 20 L 8 18 L 8 16.150391 L 8 16 L 5.7890625 16 L 2 16 z M 16 16 L 16 16.150391 L 16 18 L 16 20 L 16 22 L 22 22 L 22 16 L 18.210938 16 L 16 16 z M 4 18 L 6 18 L 6 20 L 4 20 L 4 18 z M 18 18 L 20 18 L 20 20 L 18 20 L 18 18 z "
+     id="path2"
+     style="fill:#2196f3;fill-opacity:1" />
+</svg>

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -858,5 +858,8 @@ export const fileIcons: FileIcons = {
         { name: 'disc', fileExtensions: ['iso'] },
         { name: 'fortran', fileExtensions: ['f', 'f77', 'f90', 'f95', 'f03', 'f08'] },
         { name: 'liquid', fileExtensions: ['liquid'] },
+        { name: 'shader-vert', fileExtensions: ['vert', 'vertexshader'] },
+        { name: 'shader-geom', fileExtensions: ['geom', 'geometryshader'] },
+        { name: 'shader-frag', fileExtensions: ['frag', 'fragmentshader'] },
     ]
 };


### PR DESCRIPTION
Added:

- file icon for vertex shader:<img src="https://user-images.githubusercontent.com/46566858/72440387-b14def00-37e3-11ea-8014-78b7b113005e.png" alt="vert svg" width="42">
- file icon for geometry shader:<img src="https://user-images.githubusercontent.com/46566858/72440385-b0b55880-37e3-11ea-8968-09087d7a6da7.png" alt="geom svg" width="42">
- file icon for fragment shader:<img src="https://user-images.githubusercontent.com/46566858/72440384-b01cc200-37e3-11ea-87c5-767a9b64f806.png" alt="frag svg" width="42">

Closes #597