### PR TITLE
Make filenames for license files more generic

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -317,15 +317,15 @@ export const fileIcons: FileIcons = {
       name: 'certificate',
       fileExtensions: ['cer', 'cert', 'crt'],
       fileNames: [
+        'copying',
+        'copying.md',
+        'copying.txt',
         'license',
         'license.md',
         'license.txt',
         'licence',
         'licence.md',
-        'licence.txt',
-        'unlicense',
-        'unlicense.md',
-        'unlicense.txt',
+        'licence.txt'
       ],
     },
     {


### PR DESCRIPTION
- Added "COPYING", which is, along with "LICENSE" and "LICENCE", a common generic filename for license files.

- Removed the "unlicense" filename, which is specific to a single license, and by itself does not guarantee that the file is actually a license. This reverts #474. Here are some examples of false positives:
  - [`_licenses/unlicense.txt` at github/choosealicense.com](https://github.com/github/choosealicense.com/blob/gh-pages/_licenses/unlicense.txt)
  - [`src/.../SPDX/Unlicense` at fossology/fossology](https://github.com/fossology/fossology/blob/master/src/nomos/agent_tests/testdata/NomosTestfiles/SPDX/Unlicense)
  - [`website/Unlicense` at spdx/license-list-data](https://github.com/spdx/license-list-data/blob/master/website/Unlicense)