### PR TITLE
Add json file extension to babel file association

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -648,7 +648,7 @@ export const fileIcons: FileIcons = {
                 '.env.test.local',
             ]
         },
-        { name: 'babel', fileNames: ['.babelrc', '.babelrc.js', 'babel.config.js'] },
+        { name: 'babel', fileNames: ['.babelrc', '.babelrc.js', '.babelrc.json', 'babel.config.json', 'babel.config.js'] },
         {
             name: 'contributing',
             fileNames: ['contributing.md']


### PR DESCRIPTION
Babel now supports [`babel.config.json`](https://github.com/babel/babel/pull/10501#issue-321886740) and [`.babelrc.json`](https://github.com/babel/babel/pull/10783#issue-347179686) as a valid [babel configuration file](https://babeljs.io/docs/en/config-files#supported-file-extensions).