### PR TITLE
Add additional Firebase filenames

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -726,7 +726,17 @@ export const fileIcons: FileIcons = {
             ]
         },
         { name: 'jenkins', fileNames: ['jenkinsfile'], fileExtensions: ['jenkinsfile', 'jenkins'] },
-        { name: 'firebase', fileNames: ['firebase.json', '.firebaserc'] },
+        {
+            name: 'firebase',
+            fileNames: [
+                'firebase.json',
+                '.firebaserc',
+                'firestore.rules',
+                'firestore.indexes.json',
+                'database.rules.json',
+                'storage.rules'
+            ]
+        },
         {
             name: 'rollup',
             fileNames: [

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -732,9 +732,7 @@ export const fileIcons: FileIcons = {
                 'firebase.json',
                 '.firebaserc',
                 'firestore.rules',
-                'firestore.indexes.json',
-                'database.rules.json',
-                'storage.rules'
+                'firestore.indexes.json'
             ]
         },
         {


### PR DESCRIPTION
Hi 👋 I work on a lot of Firebase projects and am always sad seeing various configuration files like `firestore.rules` with no icon. This PR adds support for some of the most common Firebase files generated by the Firebase CLI - feel free to remove some like `storage.rules` if you think those are too broad / may be used in a non-Firebase context.