### PR TITLE
add 'code' to 'folder-src' icon

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -9,7 +9,7 @@ export const folderIcons: FolderTheme[] = [
         defaultIcon: { name: 'folder' },
         rootFolder: { name: 'folder-root' },
         icons: [
-            { name: 'folder-src', folderNames: ['src', 'source', 'sources'] },
+            { name: 'folder-src', folderNames: ['src', 'source', 'sources', 'code'] },
             { name: 'folder-dist', folderNames: ['dist', 'out', 'build', 'release', 'bin'] },
             {
                 name: 'folder-css',


### PR DESCRIPTION
I've noticed a few repos that keep code in a folder called code