### PR TITLE
added .node-version filetype to nodejs association

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -607,7 +607,7 @@ export const fileIcons: FileIcons = {
         },
         {
             name: 'nodejs',
-            fileNames: ['package.json', 'package-lock.json', '.nvmrc', '.esmrc']
+            fileNames: ['package.json', 'package-lock.json', '.nvmrc', '.esmrc', '.node-version']
         },
         { name: 'npm', fileNames: ['.npmignore', '.npmrc'] },
         {


### PR DESCRIPTION
for those of us that use `nodenv` out there those configuration files should be included in the nodejs icon association as they are equally similar to an `.nvmrc` file in functionality