### PR TITLE
Add .cjs extension to ESLint icon

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -708,6 +708,7 @@ export const fileIcons: FileIcons = {
             name: 'eslint',
             fileNames: [
                 '.eslintrc.js',
+                '.eslintrc.cjs',
                 '.eslintrc.yaml',
                 '.eslintrc.yml',
                 '.eslintrc.json',


### PR DESCRIPTION
Modules are more and more use in NodeJS, in particular with the new "type": "module" option in package.json. Only, ESLint doesn't accept modules as configuration files, so we have to explicitly specify the config file as a commonJS module.
You can see [here](https://eslint.org/docs/user-guide/configuring#configuration-file-formats-1) that it is a valid ESLint config extension.