### PR TITLE
Associate docker icon to Dockerfile.prod and Dockerfile.production

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -315,6 +315,8 @@ export const fileIcons: FileIcons = {
             fileExtensions: ['dockerignore', 'dockerfile'],
             fileNames: [
                 'dockerfile',
+                'dockerfile.prod',
+                'dockerfile.production',
                 'docker-compose.yml',
                 'docker-compose.yaml',
                 'docker-compose.dev.yml',


### PR DESCRIPTION
Associate docker icon to Dockerfile.prod and Dockerfile.production, I think that is important because prod/production no have an icon and Dockerfile.prod and Dockerfile.production stay without an icon ( unknown icon )