### PR TITLE
Adjust saturation and opacity for custom file icons

### DIFF
--- a/src/helpers/customIcons.ts
+++ b/src/helpers/customIcons.ts
@@ -1,0 +1,8 @@
+import { IconJsonOptions } from '../models';
+import * as path from 'path';
+
+export const getCustomIconPaths = (options: IconJsonOptions) => {
+    return Object.values(options.files.associations)
+        .filter(v => v.match(/^[.\/]+/)) // <- custom dirs have a relative path to the dist folder
+        .map(v => path.dirname(path.join(__dirname, v)));
+};

--- a/src/helpers/fileConfig.ts
+++ b/src/helpers/fileConfig.ts
@@ -2,10 +2,10 @@ import { getDefaultIconOptions } from '../icons';
 import { IconJsonOptions } from '../models';
 
 /**
- * Generate a config string that is appended to each icon file name.
+ * Generate a config hashed string that is appended to each icon file name.
  * @param config Icon Configuration object
  */
-export const getFileConfigString = (options: IconJsonOptions) => {
+export const getFileConfigHash = (options: IconJsonOptions) => {
     try {
         const defaults = getDefaultIconOptions();
         let fileConfigString = '';

--- a/src/icons/generator/fileGenerator.ts
+++ b/src/icons/generator/fileGenerator.ts
@@ -1,5 +1,5 @@
 import * as merge from 'lodash.merge';
-import { getFileConfigString } from '../../helpers/fileConfig';
+import { getFileConfigHash } from '../../helpers/fileConfig';
 import { FileIcon, FileIcons, IconAssociations, IconConfiguration, IconJsonOptions } from '../../models/index';
 import { highContrastVersion, iconFolderPath, lightVersion, wildcardPattern } from './constants';
 
@@ -90,9 +90,9 @@ const disableIconsByPack = (fileIcons: FileIcons, activatedIconPack: string): Fi
 
 const setIconDefinition = (config: IconConfiguration, iconName: string, appendix: string = '') => {
     const obj = { iconDefinitions: {} };
-    const fileConfig = getFileConfigString(config.options);
+    const fileConfigHash = getFileConfigHash(config.options);
     obj.iconDefinitions[`${iconName}${appendix}`] = {
-        iconPath: `${iconFolderPath}${iconName}${appendix}${fileConfig}.svg`
+        iconPath: `${iconFolderPath}${iconName}${appendix}${fileConfigHash}.svg`
     };
     return obj;
 };

--- a/src/icons/generator/folderGenerator.ts
+++ b/src/icons/generator/folderGenerator.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as merge from 'lodash.merge';
 import * as path from 'path';
-import { getFileConfigString } from '../../helpers/fileConfig';
+import { getFileConfigHash } from '../../helpers/fileConfig';
 import { DefaultIcon, FolderIcon, FolderTheme, IconAssociations, IconConfiguration, IconJsonOptions } from '../../models/index';
 import { highContrastVersion, iconFolderPath, lightVersion, openedFolder } from './constants';
 
@@ -88,12 +88,12 @@ const setIconDefinitions = (config: IconConfiguration, icon: FolderIcon | Defaul
 
 const createIconDefinitions = (config: IconConfiguration, iconName: string, appendix: string = '') => {
     config = merge({}, config);
-    const fileConfig = getFileConfigString(config.options);
+    const fileConfigHash = getFileConfigHash(config.options);
     config.iconDefinitions[iconName + appendix] = {
-        iconPath: `${iconFolderPath}${iconName}${appendix}${fileConfig}.svg`
+        iconPath: `${iconFolderPath}${iconName}${appendix}${fileConfigHash}.svg`
     };
     config.iconDefinitions[`${iconName}${openedFolder}${appendix}`] = {
-        iconPath: `${iconFolderPath}${iconName}${openedFolder}${appendix}${fileConfig}.svg`
+        iconPath: `${iconFolderPath}${iconName}${openedFolder}${appendix}${fileConfigHash}.svg`
     };
     return config;
 };

--- a/src/icons/generator/iconOpacity.ts
+++ b/src/icons/generator/iconOpacity.ts
@@ -1,13 +1,15 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { getCustomIconPaths } from '../../helpers/customIcons';
+import { IconJsonOptions } from '../../models';
 
 /**
  * Changes the opacity of all icons in the set.
- * @param opacity Opacity value
+ * @param options Icon JSON options which include the opacity value.
  * @param fileNames Only change the opacity of certain file names.
  */
-export const setIconOpacity = (opacity: number, fileNames?: string[]) => {
-    if (!validateOpacityValue(opacity)) {
+export const setIconOpacity = (options: IconJsonOptions, fileNames?: string[]) => {
+    if (!validateOpacityValue(options.opacity)) {
         return console.error('Invalid opacity value! Opacity must be a decimal number between 0 and 1!');
     }
 
@@ -19,28 +21,16 @@ export const setIconOpacity = (opacity: number, fileNames?: string[]) => {
         iconsPath = path.join(__dirname, '..', '..', '..', 'icons');
     }
 
+    const customIconPaths = getCustomIconPaths(options);
+    const iconFiles = fs.readdirSync(iconsPath);
+
     try {
         // read all icon files from the icons folder
-        (fileNames || fs.readdirSync(iconsPath)).forEach(iconFileName => {
-            const svgFilePath = path.join(iconsPath, iconFileName);
+        (fileNames || iconFiles).forEach(adjustOpacity(iconsPath, options));
 
-            // Read SVG file
-            const svg = fs.readFileSync(svgFilePath, 'utf-8');
-
-            // Get the root element of the SVG file
-            const svgRootElement = getSVGRootElement(svg);
-            if (!svgRootElement) return;
-
-            let updatedRootElement: string;
-
-            if (opacity < 1) {
-                updatedRootElement = addOpacityAttribute(svgRootElement, opacity);
-            } else {
-                updatedRootElement = removeOpacityAttribute(svgRootElement);
-            }
-            const updatedSVG = svg.replace(/<svg[^>]*>/, updatedRootElement);
-
-            fs.writeFileSync(svgFilePath, updatedSVG);
+        customIconPaths.forEach(iconPath => {
+            const customIcons = fs.readdirSync(iconPath);
+            customIcons.forEach(adjustOpacity(iconPath, options));
         });
     } catch (error) {
         console.error(error);
@@ -87,3 +77,30 @@ const removeOpacityAttribute = (svgRoot: string) => {
     const pattern = new RegExp(/\sopacity="[\d.]+"/);
     return svgRoot.replace(pattern, '');
 };
+
+const adjustOpacity = (iconPath: string, options: IconJsonOptions): (value: string, index: number, array: string[]) => void => {
+    return iconFileName => {
+        const svgFilePath = path.join(iconPath, iconFileName);
+
+        // Read SVG file
+        const svg = fs.readFileSync(svgFilePath, 'utf-8');
+
+        // Get the root element of the SVG file
+        const svgRootElement = getSVGRootElement(svg);
+        if (!svgRootElement)
+            return;
+
+        let updatedRootElement: string;
+
+        if (options.opacity < 1) {
+            updatedRootElement = addOpacityAttribute(svgRootElement, options.opacity);
+        }
+        else {
+            updatedRootElement = removeOpacityAttribute(svgRootElement);
+        }
+        const updatedSVG = svg.replace(/<svg[^>]*>/, updatedRootElement);
+
+        fs.writeFileSync(svgFilePath, updatedSVG);
+    };
+};
+

--- a/src/icons/generator/iconSaturation.ts
+++ b/src/icons/generator/iconSaturation.ts
@@ -1,13 +1,15 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { getCustomIconPaths } from '../../helpers/customIcons';
+import { IconJsonOptions } from '../../models';
 
 /**
  * Changes saturation of all icons in the set.
- * @param saturation Saturation value.
+ * @param options Icon JSON options which include the saturation value.
  * @param fileNames Only change the saturation of certain file names.
  */
-export const setIconSaturation = (saturation: number, fileNames?: string[]) => {
-    if (!validateSaturationValue(saturation)) {
+export const setIconSaturation = (options: IconJsonOptions, fileNames?: string[]) => {
+    if (!validateSaturationValue(options.saturation)) {
         return console.error('Invalid saturation value! Saturation must be a decimal number between 0 and 1!');
     }
 
@@ -19,35 +21,16 @@ export const setIconSaturation = (saturation: number, fileNames?: string[]) => {
         iconsPath = path.join(__dirname, '..', '..', '..', 'icons');
     }
 
+    const customIconPaths = getCustomIconPaths(options);
+    const iconFiles = fs.readdirSync(iconsPath);
+
     // read all icon files from the icons folder
     try {
-        (fileNames || fs.readdirSync(iconsPath)).forEach(iconFileName => {
-            const svgFilePath = path.join(iconsPath, iconFileName);
+        (fileNames || iconFiles).forEach(adjustSaturation(iconsPath, options));
 
-            // Read SVG file
-            const svg = fs.readFileSync(svgFilePath, 'utf-8');
-
-            // Get the root element of the SVG file
-            const svgRootElement = getSVGRootElement(svg);
-            if (!svgRootElement) return;
-
-            let updatedRootElement: string;
-
-            if (saturation < 1) {
-                updatedRootElement = addFilterAttribute(svgRootElement);
-            } else {
-                updatedRootElement = removeFilterAttribute(svgRootElement);
-            }
-
-            let updatedSVG = svg.replace(/<svg[^>]*>/, updatedRootElement);
-
-            if (saturation < 1) {
-                updatedSVG = addFilterElement(updatedSVG, saturation);
-            } else {
-                updatedSVG = removeFilterElement(updatedSVG);
-            }
-
-            fs.writeFileSync(svgFilePath, updatedSVG);
+        customIconPaths.forEach(iconPath => {
+            const customIcons = fs.readdirSync(iconPath);
+            customIcons.forEach(adjustSaturation(iconPath, options));
         });
     } catch (error) {
         console.error(error);
@@ -115,4 +98,38 @@ const removeFilterElement = (svg: string) => {
  */
 export const validateSaturationValue = (saturation: number) => {
     return saturation !== undefined && saturation <= 1 && saturation >= 0;
+};
+
+const adjustSaturation = (iconsPath: any, options: IconJsonOptions): (value: string, index: number, array: string[]) => void => {
+    return iconFileName => {
+        const svgFilePath = path.join(iconsPath, iconFileName);
+
+        // Read SVG file
+        const svg = fs.readFileSync(svgFilePath, 'utf-8');
+
+        // Get the root element of the SVG file
+        const svgRootElement = getSVGRootElement(svg);
+        if (!svgRootElement)
+            return;
+
+        let updatedRootElement: string;
+
+        if (options.saturation < 1) {
+            updatedRootElement = addFilterAttribute(svgRootElement);
+        }
+        else {
+            updatedRootElement = removeFilterAttribute(svgRootElement);
+        }
+
+        let updatedSVG = svg.replace(/<svg[^>]*>/, updatedRootElement);
+
+        if (options.saturation < 1) {
+            updatedSVG = addFilterElement(updatedSVG, options.saturation);
+        }
+        else {
+            updatedSVG = removeFilterElement(updatedSVG);
+        }
+
+        fs.writeFileSync(svgFilePath, updatedSVG);
+    };
 };

--- a/src/icons/generator/jsonGenerator.ts
+++ b/src/icons/generator/jsonGenerator.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs';
 import * as merge from 'lodash.merge';
 import * as path from 'path';
-import { getFileConfigString } from '../../helpers/fileConfig';
+import { getCustomIconPaths } from '../../helpers/customIcons';
+import { getFileConfigHash } from '../../helpers/fileConfig';
 import { IconConfiguration, IconJsonOptions } from '../../models/index';
 import { fileIcons } from '../fileIcons';
 import { folderIcons } from '../folderIcons';
@@ -43,6 +44,11 @@ export const createIconFile = (updatedConfigs?: IconJsonOptions, updatedJSONConf
     }
 
     try {
+        let iconJsonPath = __dirname;
+        // if executed via script
+        if (path.basename(__dirname) !== 'dist') {
+            iconJsonPath = path.join(__dirname, '..', '..', '..', 'dist');
+        }
         if (!updatedConfigs || (updatedConfigs.folders || {}).color) {
             // if updatedConfigs do not exist (because of initial setup)
             // or new config value was detected by the change detection
@@ -54,11 +60,6 @@ export const createIconFile = (updatedConfigs?: IconJsonOptions, updatedJSONConf
         }
         if (!updatedConfigs || updatedConfigs.saturation !== undefined) {
             setIconSaturation(options.saturation);
-        }
-        let iconJsonPath = __dirname;
-        // if executed via script
-        if (path.basename(__dirname) !== 'dist') {
-            iconJsonPath = path.join(__dirname, '..', '..', '..', 'dist');
         }
         renameIconFiles(iconJsonPath, options);
     } catch (error) {
@@ -102,20 +103,26 @@ export const getDefaultIconOptions = (): IconJsonOptions => ({
  * @param options Icon Json Options
  */
 const renameIconFiles = (iconJsonPath: string, options: IconJsonOptions) => {
-    fs.readdirSync(path.join(iconJsonPath, '..', 'icons'))
-        .filter(f => f.match(/\.svg/gi))
-        .forEach(f => {
-            const filePath = path.join(iconJsonPath, '..', 'icons', f);
-            const fileConfig = getFileConfigString(options);
+    const customPaths = getCustomIconPaths(options);
+    const defaultIconPath = path.join(iconJsonPath, '..', 'icons');
+    const iconPaths = [defaultIconPath, ...customPaths];
 
-            // append file config to file name
-            const newFilePath = path.join(iconJsonPath, '..', 'icons', f.replace(/(^[^\.~]+)(.*)\.svg/, `$1${fileConfig}.svg`));
+    iconPaths.forEach(iconPath => {
+        fs.readdirSync(iconPath)
+            .filter(f => f.match(/\.svg/gi))
+            .forEach(f => {
+                const filePath = path.join(iconPath, f);
+                const fileConfigHash = getFileConfigHash(options);
 
-            // if generated files are already in place, do not overwrite them
-            if (filePath !== newFilePath && fs.existsSync(newFilePath)) {
-                fs.unlinkSync(filePath);
-            } else {
-                fs.renameSync(filePath, newFilePath);
-            }
-        });
+                // append file config to file name
+                const newFilePath = path.join(iconPath, f.replace(/(^[^\.~]+)(.*)\.svg/, `$1${fileConfigHash}.svg`));
+
+                // if generated files are already in place, do not overwrite them
+                if (filePath !== newFilePath && fs.existsSync(newFilePath)) {
+                    fs.unlinkSync(filePath);
+                } else {
+                    fs.renameSync(filePath, newFilePath);
+                }
+            });
+    });
 };

--- a/src/icons/generator/jsonGenerator.ts
+++ b/src/icons/generator/jsonGenerator.ts
@@ -53,13 +53,13 @@ export const createIconFile = (updatedConfigs?: IconJsonOptions, updatedJSONConf
             // if updatedConfigs do not exist (because of initial setup)
             // or new config value was detected by the change detection
             generateFolderIcons(options.folders.color);
-            setIconOpacity(options.opacity, ['folder.svg', 'folder-open.svg', 'folder-root.svg', 'folder-root-open.svg']);
+            setIconOpacity(options, ['folder.svg', 'folder-open.svg', 'folder-root.svg', 'folder-root-open.svg']);
         }
         if (!updatedConfigs || updatedConfigs.opacity !== undefined) {
-            setIconOpacity(options.opacity);
+            setIconOpacity(options);
         }
         if (!updatedConfigs || updatedConfigs.saturation !== undefined) {
-            setIconSaturation(options.saturation);
+            setIconSaturation(options);
         }
         renameIconFiles(iconJsonPath, options);
     } catch (error) {

--- a/src/icons/generator/languageGenerator.ts
+++ b/src/icons/generator/languageGenerator.ts
@@ -1,5 +1,5 @@
 import * as merge from 'lodash.merge';
-import { getFileConfigString } from '../../helpers/fileConfig';
+import { getFileConfigHash } from '../../helpers/fileConfig';
 import { DefaultIcon, IconAssociations, IconConfiguration, IconJsonOptions, LanguageIcon } from '../../models/index';
 import { highContrastVersion, iconFolderPath, lightVersion } from './constants';
 
@@ -33,9 +33,9 @@ const setIconDefinitions = (config: IconConfiguration, icon: DefaultIcon) => {
 
 const createIconDefinitions = (config: IconConfiguration, iconName: string) => {
     config = merge({}, config);
-    const fileConfig = getFileConfigString(config.options);
+    const fileConfigHash = getFileConfigHash(config.options);
     config.iconDefinitions[iconName] = {
-        iconPath: `${iconFolderPath}${iconName}${fileConfig}.svg`
+        iconPath: `${iconFolderPath}${iconName}${fileConfigHash}.svg`
     };
     return config;
 };


### PR DESCRIPTION
This pull requests fixes #827 and allows the extension to update the saturation and the opacity of custom SVG files.