### PR TITLE
Added types to folder-typescript

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -108,7 +108,7 @@ export const folderIcons: FolderTheme[] = [
             { name: 'folder-coverage', folderNames: ['coverage', '.nyc-output', '.nyc_output', 'e2e', 'it', 'integration-test', 'integration-tests'] },
             { name: 'folder-class', folderNames: ['class', 'classes', 'model', 'models'] },
             { name: 'folder-other', folderNames: ['other', 'others', 'misc', 'miscellaneous', 'extra', 'extras'] },
-            { name: 'folder-typescript', folderNames: ['typescript', 'ts', 'typings', '@types'] },
+            { name: 'folder-typescript', folderNames: ['typescript', 'ts', 'typings', '@types', 'types'] },
             { name: 'folder-graphql', folderNames: ['graphql', 'gql'] },
             { name: 'folder-routes', folderNames: ['routes', 'router', 'routers'] },
             { name: 'folder-ci', folderNames: ['.ci', 'ci'] },


### PR DESCRIPTION
 I know you can create custom icon mappings like so:
```
"material-icon-theme.folders.associations": {
    "customFolderName": "types",
    "types": "typescript"
},
```
but I feel this small change is justified.