### PR TITLE
Add proto icons (#902)

### DIFF
--- a/icons/proto.svg
+++ b/icons/proto.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="200" height="200" version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+ <g transform="translate(2.3164 2.3727)" stroke-width="1.7857">
+  <path d="m11.449 79.335 86.235-56.606v36.585l-86.235 56.606z" fill="#ff5722"/>
+  <path d="m11.449 115.92 86.235 56.606v-36.585l-86.235-56.606z" fill="#03a9f4"/>
+  <path d="m183.92 115.92-86.235 56.606v-36.585l86.235-56.606z" fill="#ffeb3b"/>
+  <path d="m183.92 79.335-86.235-56.606v36.585l86.235 56.606z" fill="#00e676"/>
+ </g>
+</svg>

--- a/icons/proto.svg
+++ b/icons/proto.svg
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="200" height="200" version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
- <g transform="translate(2.3164 2.3727)" stroke-width="1.7857">
+<svg version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+ <g transform="matrix(.95676 0 0 .95676 6.5391 6.5936)" stroke-width="1.7857">
   <path d="m11.449 79.335 86.235-56.606v36.585l-86.235 56.606z" fill="#ff5722"/>
   <path d="m11.449 115.92 86.235 56.606v-36.585l-86.235-56.606z" fill="#03a9f4"/>
   <path d="m183.92 115.92-86.235 56.606v-36.585l86.235-56.606z" fill="#ffeb3b"/>

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -39,6 +39,10 @@ export const fileIcons: FileIcons = {
       light: true,
     },
     {
+      name: 'proto',
+      fileExtensions: ['proto'],
+    },
+    {
       name: 'sublime',
       fileExtensions: ['sublime-project', 'sublime-workspace'],
     },

--- a/src/icons/languageIcons.ts
+++ b/src/icons/languageIcons.ts
@@ -97,6 +97,7 @@ export const languageIcons: LanguageIcon[] = [
   { icon: { name: 'groovy' }, ids: ['groovy'] },
   { icon: { name: 'markdown' }, ids: ['markdown'] },
   { icon: { name: 'jinja' }, ids: ['jinja'] },
+  { icon: { name: 'proto' }, ids: ['proto'] },
   { icon: { name: 'python-misc' }, ids: ['pip-requirements'] },
   { icon: { name: 'vue' }, ids: ['vue', 'vue-postcss', 'vue-html'] },
   { icon: { name: 'lua' }, ids: ['lua'] },


### PR DESCRIPTION
Added a custom icon for .proto files, inspired by google's icon for protocol 
![proto](https://user-images.githubusercontent.com/69708588/109414895-ac460200-79db-11eb-9570-d967adf634b2.png)


