### PR TITLE
Show `svelte.config.cjs` as svelte file

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1193,7 +1193,7 @@ export const fileIcons: FileIcons = {
     {
       name: 'svelte',
       fileExtensions: ['svelte'],
-      fileNames: ['svelte.config.js'],
+      fileNames: ['svelte.config.js', 'svelte.config.cjs'],
     },
     {
       name: 'vim',


### PR DESCRIPTION
SvelteKit has been using `svelte.config.cjs` for it's config file, so this shows it with a svelte icon as well as `svelte.config.js`.