### PR TITLE
add 'inc' to 'folder-include' folder names

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -185,7 +185,7 @@ export const folderIcons: FolderTheme[] = [
       },
       {
         name: 'folder-include',
-        folderNames: ['include', 'includes', '_includes'],
+        folderNames: ['include', 'includes', '_includes', 'inc'],
       },
       {
         name: 'folder-docker',


### PR DESCRIPTION
Simply add `inc` to the list of folder names that use `folder-include` icon.