### PR TITLE
added .env.template to .env recognized filenames

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -816,6 +816,7 @@ export const fileIcons: FileIcons = {
         '.env.defaults',
         '.env.example',
         '.env.sample',
+        '.env.template',
         '.env.schema',
         '.env.local',
         '.env.dev',


### PR DESCRIPTION
I believe `.env.template` is reasonable and good name for .env files and in some cases might be more suitable than .sample, .defaults, .example, .schema etc.