### PR TITLE
Update Gitpod icon

### DIFF
--- a/icons/gitpod.svg
+++ b/icons/gitpod.svg
@@ -1,1 +1,14 @@
-<svg version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g transform="translate(.59804 .69053)"><polygon class="cls-1" transform="matrix(.10563 0 0 .10563 1.9634 .41108)" points="0 51.6 0 154.76 0 154.77 89.35 206.35 89.35 185.6 17.74 144.58 17.74 61.87 17.77 61.85" style="fill:#0288d1"/><polygon class="cls-1" transform="matrix(.10563 0 0 .10563 1.9634 .41108)" points="35.77 72.25 35.74 72.27 35.74 134.15 89.35 164.86 89.35 103.19 89.35 103.18" style="fill:#0288d1"/><polygon class="cls-2" transform="matrix(.10563 0 0 .10563 1.9634 .41108)" points="89.35 0 0 51.59 0 51.6 17.77 61.85 89.35 20.55 160.98 61.83 178.7 51.61 178.7 51.62 178.71 51.62 178.71 51.61" style="fill:#29b6f6"/><polygon class="cls-2" transform="matrix(.10563 0 0 .10563 1.9634 .41108)" points="89.36 41.33 35.77 72.25 89.35 103.18 142.97 72.23" style="fill:#29b6f6"/><polygon class="cls-3" transform="matrix(.10563 0 0 .10563 1.9634 .41108)" points="89.35 103.18 89.35 103.19" style="fill:#0092cf"/><polygon class="cls-3" transform="matrix(.10563 0 0 .10563 1.9634 .41108)" points="142.98 72.23 142.97 72.23 89.35 103.18" style="fill:#0092cf"/><polygon class="cls-3" transform="matrix(.10563 0 0 .10563 1.9634 .41108)" points="160.99 61.84 178.7 51.62 178.7 51.61 160.98 61.83" style="fill:#0092cf"/><polygon class="cls-4" transform="matrix(.10563 0 0 .10563 1.9634 .41108)" points="160.99 61.84 160.98 61.83 142.97 72.23 142.98 72.23" style="fill:#e8bfd8"/><polygon class="cls-3" transform="matrix(.10563 0 0 .10563 1.9634 .41108)" points="178.7 154.78 178.7 154.78 178.7 154.77 178.7 51.62 160.99 61.84 142.98 72.23 89.35 103.18 89.35 103.19 89.35 112.41 89.34 112.41 89.34 136.91 89.35 136.91 89.35 164.86 143.02 134.14 143.02 113.66 107.01 134.15 107.01 113.44 161.02 82.7 161.02 144.58 89.35 185.6 89.35 206.35" style="fill:#039be5"/></g></svg>
+<svg viewBox="0 0 24 24" height="24" width="24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g clip-path="url(#clip0)">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M14.07 1.195a2.364 2.364 0 01-.887 3.236l-7.11 4.04a.6.6 0 00-.304.52v6.343a.6.6 0 00.304.52l5.628 3.199a.605.605 0 00.598 0l5.628-3.198a.6.6 0 00.304-.521V11.39l-5.06 2.838a2.392 2.392 0 01-3.248-.9 2.364 2.364 0 01.905-3.23l7.239-4.062C20.272 4.8 23 6.383 23 8.901v6.914c0 1.62-.873 3.115-2.287 3.919l-6.461 3.671a4.56 4.56 0 01-4.504 0l-6.461-3.671A4.509 4.509 0 011 15.815V8.51c0-1.62.873-3.115 2.287-3.918l7.53-4.28a2.392 2.392 0 013.253.883z" fill="url(#paint0_linear)" />
+  </g>
+  <defs>
+    <linearGradient id="paint0_linear" x1="17.558" y1="3.629" x2="6.356" y2="21.34" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFB45B" />
+      <stop offset="1" stop-color="#FF8A00" />
+    </linearGradient>
+    <clipPath id="clip0">
+      <path fill="#fff" d="M0 0h24v24H0z" />
+    </clipPath>
+  </defs>
+</svg>


### PR DESCRIPTION
Gitpod was redesigned on [April 8, 2021](https://www.gitpod.io/blog/next-chapter-for-gitpod): the logo should be updated.

Source of the icon: www.gitpod.io/svg/logo-textless.svg