### PR TITLE
Add webpack.mix.js icon association

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -725,6 +725,7 @@ export const fileIcons: FileIcons = {
         'webpack.config.dev.ts',
         'webpack.config.dev.babel.js',
         'webpack.config.dev.babel.ts',
+        'webpack.mix.js',
         'webpack.prod.js',
         'webpack.prod.config.js',
         'webpack.prod.ts',


### PR DESCRIPTION
Applies Webpack icon to webpack.mix.js. Requested in #997.

Does the Webpack icon look better with the white fill?