### PR TITLE
Add artisan icon association

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -650,7 +650,11 @@ export const fileIcons: FileIcons = {
       name: 'terraform',
       fileExtensions: ['tf', 'tf.json', 'tfvars', 'tfstate'],
     },
-    { name: 'laravel', fileExtensions: ['blade.php', 'inky.php'] },
+    {
+      name: 'laravel',
+      fileExtensions: ['blade.php', 'inky.php'],
+      fileNames: ['artisan']
+    },
     { name: 'applescript', fileExtensions: ['applescript', 'ipa'] },
     { name: 'cake', fileExtensions: ['cake'] },
     { name: 'cucumber', fileExtensions: ['feature'] },


### PR DESCRIPTION
The `artisan` script is used by Laravel's Artisan CLI for application build. [Sample](https://github.com/laravel/laravel/blob/8.x/artisan).