### PR TITLE
Add Hex file icon

### DIFF
--- a/icons/hex.svg
+++ b/icons/hex.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="hex.svg"
+   id="svg4"
+   viewBox="0 0 24 24"
+   height="24"
+   width="24"
+   version="1.1">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="22.567777"
+     inkscape:cx="-10.972139"
+     inkscape:zoom="14.166667"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="847"
+     inkscape:window-width="1600"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     inkscape:document-rotation="0" />
+  <path
+     id="path2"
+     style="fill:#26a69a;fill-opacity:1;stroke-width:1.18115"
+     d="m 14.770718,11.549205 -1.665878,1.641586 2.499632,2.460783 -2.499632,2.460782 1.665878,1.639988 2.501256,-2.46078 2.499632,2.46078 1.665876,-1.639988 -2.499629,-2.460782 2.499631,-2.460783 -1.665878,-1.641586 -2.499632,2.46078 z" />
+  <path
+     id="path837"
+     style="fill:#26a69a;fill-opacity:1;stroke-width:1.50263"
+     d="m 5.9881462,4.5008425 c -1.6435353,0 -2.9884048,1.3602032 -2.9884048,3.0224777 V 16.58869 c 0,1.677385 1.3448695,3.022477 2.9884048,3.022477 h 2.988411 c 1.6584778,0 2.9884018,-1.345092 2.9884018,-3.022477 V 7.5233202 c 0,-1.6622746 -1.329924,-3.0224777 -2.9884018,-3.0224777 z m 0,3.0224777 h 2.988411 V 16.58869 h -2.988411 z" />
+</svg>

--- a/icons/hex.svg
+++ b/icons/hex.svg
@@ -1,60 +1,7 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
-   sodipodi:docname="hex.svg"
-   id="svg4"
-   viewBox="0 0 24 24"
-   height="24"
-   width="24"
-   version="1.1">
-  <metadata
-     id="metadata10">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
-     id="defs8" />
-  <sodipodi:namedview
-     inkscape:current-layer="svg4"
-     inkscape:window-maximized="1"
-     inkscape:window-y="-8"
-     inkscape:window-x="-8"
-     inkscape:cy="22.567777"
-     inkscape:cx="-10.972139"
-     inkscape:zoom="14.166667"
-     showgrid="false"
-     id="namedview6"
-     inkscape:window-height="847"
-     inkscape:window-width="1600"
-     inkscape:pageshadow="2"
-     inkscape:pageopacity="0"
-     guidetolerance="10"
-     gridtolerance="10"
-     objecttolerance="10"
-     borderopacity="1"
-     bordercolor="#666666"
-     pagecolor="#ffffff"
-     inkscape:document-rotation="0" />
-  <path
-     id="path2"
-     style="fill:#26a69a;fill-opacity:1;stroke-width:1.18115"
-     d="m 14.770718,11.549205 -1.665878,1.641586 2.499632,2.460783 -2.499632,2.460782 1.665878,1.639988 2.501256,-2.46078 2.499632,2.46078 1.665876,-1.639988 -2.499629,-2.460782 2.499631,-2.460783 -1.665878,-1.641586 -2.499632,2.46078 z" />
-  <path
-     id="path837"
-     style="fill:#26a69a;fill-opacity:1;stroke-width:1.50263"
-     d="m 5.9881462,4.5008425 c -1.6435353,0 -2.9884048,1.3602032 -2.9884048,3.0224777 V 16.58869 c 0,1.677385 1.3448695,3.022477 2.9884048,3.022477 h 2.988411 c 1.6584778,0 2.9884018,-1.345092 2.9884018,-3.022477 V 7.5233202 c 0,-1.6622746 -1.329924,-3.0224777 -2.9884018,-3.0224777 z m 0,3.0224777 h 2.988411 V 16.58869 h -2.988411 z" />
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+ <g transform="translate(-.21861 -.12659)" fill="#26a69a">
+  <path d="m14.771 11.549-1.6659 1.6416 2.4996 2.4608-2.4996 2.4608 1.6659 1.64 2.5013-2.4608 2.4996 2.4608 1.6659-1.64-2.4996-2.4608 2.4996-2.4608-1.6659-1.6416-2.4996 2.4608z" stroke-width="1.1812"/>
+  <path d="m5.9881 4.5008c-1.6435 0-2.9884 1.3602-2.9884 3.0225v9.0654c0 1.6774 1.3449 3.0225 2.9884 3.0225h2.9884c1.6585 0 2.9884-1.3451 2.9884-3.0225v-9.0654c0-1.6623-1.3299-3.0225-2.9884-3.0225zm0 3.0225h2.9884v9.0654h-2.9884z" stroke-width="1.5026"/>
+ </g>
 </svg>

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -277,6 +277,7 @@ export const fileIcons: FileIcons = {
     { name: 'vala', fileExtensions: ['vala'] },
     { name: 'zig', fileExtensions: ['zig'] },
     { name: 'exe', fileExtensions: ['exe', 'msi'] },
+    { name: 'hex', fileExtensions: ['dat', 'bin', 'hex'] },
     { name: 'java', fileExtensions: ['java', 'jar', 'jsp'] },
     { name: 'javaclass', fileExtensions: ['class'] },
     { name: 'c', fileExtensions: ['c', 'm', 'i', 'mi'] },


### PR DESCRIPTION
This closes #1061

---

![prev](https://user-images.githubusercontent.com/49621788/119706416-f0547180-be27-11eb-991e-856743710c16.png)

A new icon for `.dat`, `.hex` and `.bin` files.

Inspired by the fact that these files can be opened/edited with [Hex Editor](https://marketplace.visualstudio.com/items?itemName=ms-vscode.hexeditor), I think the '0x' icon makes sense.

![image](https://user-images.githubusercontent.com/49621788/119705540-dc5c4000-be26-11eb-9693-e9712fea6627.png)

I extracted the icon from [Material Design Icons](https://materialdesignicons.com/) and adjusted a little for pixel-correction.