### PR TITLE
Adding new extension of storybook CSF format for svelte

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1110,6 +1110,7 @@ export const fileIcons: FileIcons = {
         'stories.tsx',
         'story.ts',
         'story.tsx',
+        'stories.svelte',
       ],
     },
     { name: 'wepy', fileExtensions: ['wpy'] },


### PR DESCRIPTION
Since the storybook added full support for svelte and has added support for CSF we can create stories using `stories.svelte` format to stick to the svelte style of creating components.