### PR TITLE
Add eslint config for markdown documentation

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -927,6 +927,7 @@ export const fileIcons: FileIcons = {
         '.eslintrc.yaml',
         '.eslintrc.yml',
         '.eslintrc.json',
+        '.eslintrc-md.js',
         '.eslintrc',
         '.eslintignore',
         '.eslintcache',


### PR DESCRIPTION
Located in Gutenberg project: https://github.com/WordPress/gutenberg/tree/trunk/packages/scripts/config

CC @PKief 