### PR TITLE
Fix - Missing JavaScript and TypeScript file icons in chrome extension

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -122,7 +122,7 @@ export const fileIcons: FileIcons = {
         'pnm',
       ],
     },
-    { name: 'javascript', fileExtensions: ['esx', 'mjs'] },
+    { name: 'javascript', fileExtensions: ['js', 'esx', 'mjs'] },
     { name: 'react', fileExtensions: ['jsx'] },
     { name: 'react_ts', fileExtensions: ['tsx'] },
     {
@@ -208,6 +208,7 @@ export const fileIcons: FileIcons = {
         '.clang-tidy',
       ],
     },
+    { name: 'typescript', fileExtensions: ['ts'] },
     { name: 'typescript-def', fileExtensions: ['d.ts'] },
     { name: 'markojs', fileExtensions: ['marko'] },
     { name: 'astro', fileExtensions: ['astro'] },


### PR DESCRIPTION
Seems like the file extension was missing while generating JSON for material icons.

Before:
![image](https://user-images.githubusercontent.com/3774827/123018390-303e5280-d3ee-11eb-85df-339a58c57da3.png)

After:
![image](https://user-images.githubusercontent.com/3774827/123018618-9dea7e80-d3ee-11eb-895e-ab44629c315c.png)

CC @PKief 