### PR TITLE
Add folder `.wordpress-org` support

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -281,7 +281,7 @@ export const folderIcons: FolderTheme[] = [
       { name: 'folder-export', folderNames: ['export', 'exports', 'exported'] },
       { name: 'folder-wakatime', folderNames: ['wakatime'] },
       { name: 'folder-circleci', folderNames: ['.circleci'] },
-      { name: 'folder-wordpress', folderNames: ['wp-content'] },
+      { name: 'folder-wordpress', folderNames: ['.wordpress-org', 'wp-content'] },
       { name: 'folder-gradle', folderNames: ['gradle', '.gradle'] },
       {
         name: 'folder-coverage',


### PR DESCRIPTION
This is also the WordPress folder to store plugins and themes SVN assets during development.