### PR TITLE
Add support for `sample-data` folder

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -437,12 +437,13 @@ export const folderIcons: FolderTheme[] = [
       {
         name: 'folder-examples',
         folderNames: [
+          'demo',
+          'demos',
           'example',
           'examples',
           'sample',
           'samples',
-          'demo',
-          'demos',
+          'sample-data',
         ],
       },
       {


### PR DESCRIPTION
This folder is used to store dummy sample data for WordPress plugins.

Ref: https://github.com/woocommerce/woocommerce