### PR TITLE
Add XML support for PHP_CodeSniffer ruleset file

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -48,7 +48,16 @@ export const fileIcons: FileIcons = {
       fileExtensions: ['sublime-project', 'sublime-workspace'],
     },
     { name: 'twine', fileExtensions: ['tw', 'twee'] },
-    { name: 'yaml', fileExtensions: ['yaml', 'YAML-tmLanguage', 'yml', 'yml.dist'] },
+    {
+      name: 'yaml',
+      fileExtensions: [
+        'yml',
+        'yaml',
+        'yml.dist',
+        'yaml.dist',
+        'YAML-tmLanguage',
+      ],
+    },
     {
       name: 'xml',
       fileExtensions: [
@@ -544,12 +553,15 @@ export const fileIcons: FileIcons = {
       ],
     },
     { name: 'vue', fileExtensions: ['vue'] },
-    { name: 'vue-config', fileNames: [
-      'vue.config.js',
-      'vue.config.ts',
-      'vetur.config.js',
-      'vetur.config.ts'
-    ] },
+    {
+      name: 'vue-config',
+      fileNames: [
+        'vue.config.js',
+        'vue.config.ts',
+        'vetur.config.js',
+        'vetur.config.ts',
+      ],
+    },
     {
       name: 'vuex-store',
       fileExtensions: ['store.js', 'store.ts'],
@@ -930,6 +942,7 @@ export const fileIcons: FileIcons = {
         '.eslintrc.yml',
         '.eslintrc.json',
         '.eslintrc-md.js',
+        '.eslintrc-jsdoc.js',
         '.eslintrc',
         '.eslintignore',
         '.eslintcache',
@@ -1473,10 +1486,7 @@ export const fileIcons: FileIcons = {
     { name: 'robots', fileNames: ['robots.txt'] },
     {
       name: 'tsconfig',
-      fileNames: [
-        'tsconfig.json',
-        'tsconfig.base.json'
-      ],
+      fileNames: ['tsconfig.json', 'tsconfig.base.json'],
       fileExtensions: ['tsconfig.json'],
     },
     {
@@ -1486,11 +1496,7 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'ember',
-      fileNames: [
-          '.ember-cli',
-          '.ember-cli.js',
-          'ember-cli-builds.js'
-      ]
+      fileNames: ['.ember-cli', '.ember-cli.js', 'ember-cli-builds.js'],
     },
     {
       name: 'horusec',

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -65,7 +65,11 @@ export const fileIcons: FileIcons = {
         'manifest',
         'project',
       ],
-      fileNames: ['.htaccess'],
+      fileNames: [
+        '.htaccess'
+        'phpcs.xml.dist',
+        '.phpcs.xml.dist',
+      ],
     },
     {
       name: 'image',

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -48,7 +48,7 @@ export const fileIcons: FileIcons = {
       fileExtensions: ['sublime-project', 'sublime-workspace'],
     },
     { name: 'twine', fileExtensions: ['tw', 'twee'] },
-    { name: 'yaml', fileExtensions: ['yaml', 'YAML-tmLanguage', 'yml'] },
+    { name: 'yaml', fileExtensions: ['yaml', 'YAML-tmLanguage', 'yml', 'yml.dist'] },
     {
       name: 'xml',
       fileExtensions: [
@@ -64,12 +64,9 @@ export const fileIcons: FileIcons = {
         'tmLanguage',
         'manifest',
         'project',
+        'xml.dist',
       ],
-      fileNames: [
-        '.htaccess',
-        'phpcs.xml.dist',
-        '.phpcs.xml.dist',
-      ],
+      fileNames: ['.htaccess'],
     },
     {
       name: 'image',
@@ -933,7 +930,6 @@ export const fileIcons: FileIcons = {
         '.eslintrc.yml',
         '.eslintrc.json',
         '.eslintrc-md.js',
-        '.eslintrc-jsdoc.js',
         '.eslintrc',
         '.eslintignore',
         '.eslintcache',

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -66,7 +66,7 @@ export const fileIcons: FileIcons = {
         'project',
       ],
       fileNames: [
-        '.htaccess'
+        '.htaccess',
         'phpcs.xml.dist',
         '.phpcs.xml.dist',
       ],


### PR DESCRIPTION
Ref: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file