### PR TITLE
Add ESLint config for JSDoc documentation

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -929,6 +929,7 @@ export const fileIcons: FileIcons = {
         '.eslintrc.yml',
         '.eslintrc.json',
         '.eslintrc-md.js',
+        '.eslintrc-jsdoc.js',
         '.eslintrc',
         '.eslintignore',
         '.eslintcache',


### PR DESCRIPTION
Enable JSDocs to be linted with ESLint and is used in core WordPress software development repo.

Ref: https://github.com/WordPress/wordpress-develop