### PR TITLE
Add support for git-hooks as console file icon

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -332,6 +332,7 @@ export const fileIcons: FileIcons = {
         'fish',
         'exp',
       ],
+      fileNames: ['pre-commit', 'pre-push', 'post-merge'],
     },
     {
       name: 'powershell',


### PR DESCRIPTION
The husky tool is great for git hooks and those files are shell scripts. Since `sh` is denoted for the console icon we can adapt those for git hooks because they are shell scripts overall. On a new git init browse `.git/hooks` folder and those all are shell scripts although there is no extension `sh`.

Ref: https://github.com/wpeverest/everest-forms/tree/develop/.husky

CC @PKief 