### PR TITLE
Allow folder icon for patches collection

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -84,6 +84,7 @@ export const folderIcons: FolderTheme[] = [
         name: 'folder-git',
         folderNames: [
           '.git',
+          'patches',
           'githooks',
           '.githooks',
           'submodules',


### PR DESCRIPTION
It denotes the collection of patches and file extension `.patch` has git icon https://github.com/PKief/vscode-material-icon-theme/blob/bd1142e717d4211819fd04f75ab5052041209e3d/src/icons/fileIcons.ts#L514

Ref for the patches directory: https://github.com/WordPress/gutenberg/tree/trunk/patches

CC @PKief