### PR TITLE
Routes pkg to packages icon by default (4 Go devs)

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -504,7 +504,13 @@ export const folderIcons: FolderTheme[] = [
       },
       { name: 'folder-mappings', folderNames: ['mappings', 'mapping'] },
       { name: 'folder-meta', folderNames: ['meta'] },
-      { name: 'folder-packages', folderNames: ['package', 'packages'] },
+      { name: 'folder-packages', 
+        folderNames: [
+          'package', 
+          'packages',
+          'pkg'
+        ] 
+      },
       { name: 'folder-shared', folderNames: ['shared', 'common'] },
       { name: 'folder-stack', folderNames: ['stack', 'stacks'] },
       { name: 'folder-template', folderNames: ['template', 'templates'] },


### PR DESCRIPTION
Go pkg folder routes to packages icon by default now.

Closes #1251 