### PR TITLE
fileicon added for go.work file

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -314,7 +314,7 @@ export const fileIcons: FileIcons = {
       fileExtensions: ['hh', 'hpp', 'hxx', 'h++', 'hp', 'tcc', 'inl'],
     },
     { name: 'go', fileExtensions: ['go'] },
-    { name: 'go-mod', fileNames: ['go.mod', 'go.sum'] },
+    { name: 'go-mod', fileNames: ['go.mod', 'go.sum', 'go.work'] },
     { name: 'python', fileExtensions: ['py'] },
     {
       name: 'python-misc',


### PR DESCRIPTION
Need file icon for go.work (Go workspace feature)
It will be released in go1.18 version 

[go.work proposal](https://go.googlesource.com/proposal/+/master/design/45713-workspace.md#proposal-the-file)