### PR TITLE
Add "renovate-config.json" to renovate filenames

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1132,6 +1132,7 @@ export const fileIcons: FileIcons = {
       fileNames: [
         '.renovaterc',
         '.renovaterc.json',
+        'renovate-config.json',
         'renovate.json',
         'renovate.json5',
       ],


### PR DESCRIPTION
According to https://github.com/renovatebot/renovate/pull/7423, `renovate-config.json` is a valid config file name for organization-wide presets, so I think it should be added here to reflect that.