### PR TITLE
Add `pom.xml` to maven files

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1711,7 +1711,7 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'maven',
-      fileNames: ['maven.config', 'jvm.config'],
+      fileNames: ['maven.config', 'jvm.config', 'pom.xml'],
     },
     { name: 'ada', fileExtensions: ['ada', 'adb', 'ads', 'ali'] },
     { name: 'serverless', fileNames: ['serverless.yml'] },


### PR DESCRIPTION
`pom.xml` is the file name for the maven Project Object Model, and is in every maven project. As the maven icon already exists, applying it to `pom.xml` makes sense.