### PR TITLE
Add Svelte-Kit to be included with the folder-svelte.

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -608,7 +608,7 @@ export const folderIcons: FolderTheme[] = [
       },
       { name: 'folder-stencil', folderNames: ['.stencil'] },
       { name: 'folder-firebase', folderNames: ['.firebase'] },
-      { name: 'folder-svelte', folderNames: ['svelte'] },
+      { name: 'folder-svelte', folderNames: ['svelte', '.svelte-kit'] },
       {
         name: 'folder-update',
         folderNames: ['update', 'updates', 'upgrade', 'upgrades'],


### PR DESCRIPTION
Currently, the svelte logo and color only runs for a folder called 'svelte'. However, it is rare for a folder to be called 'svelte'. However, now that Svelte-kIt is gaining in popularity, you will have many folders called '.svelte-kit' as this is the build folder for Svelte Kit. 

Solves: https://github.com/PKief/vscode-material-icon-theme/issues/1404

P.S. Thank you for this project. It is fun and really awesome. 