### PR TITLE
Improve range of language `Makefile`

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1299,7 +1299,11 @@ export const fileIcons: FileIcons = {
     { name: 'django', fileExtensions: ['djt'] },
     { name: 'stencil', fileNames: ['stencil.config.js', 'stencil.config.ts'] },
     { name: 'red', fileExtensions: ['red'] },
-    { name: 'makefile', fileNames: ['makefile'] },
+    {
+      name: 'makefile',
+      fileExtensions: ['mk'],
+      fileNames: ['makefile', 'gnumakefile', 'kbuild'],
+    },
     { name: 'foxpro', fileExtensions: ['fxp', 'prg'] },
     { name: 'i18n', fileExtensions: ['pot', 'po', 'mo'] },
     { name: 'webassembly', fileExtensions: ['wat', 'wasm'] },

--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -608,7 +608,7 @@ export const folderIcons: FolderTheme[] = [
       },
       { name: 'folder-stencil', folderNames: ['.stencil'] },
       { name: 'folder-firebase', folderNames: ['.firebase'] },
-      { name: 'folder-svelte', folderNames: ['svelte'] },
+      { name: 'folder-svelte', folderNames: ['svelte', '.svelte-kit'] },
       {
         name: 'folder-update',
         folderNames: ['update', 'updates', 'upgrade', 'upgrades'],


### PR DESCRIPTION
This improves support for Makefiles by using the icon in more contexts where it is applicable

`.mk` files, `Kbuild` and `GNUMakefile` are now all highlighted

In the [kernel docs](https://www.kernel.org/doc/html/latest/kbuild/modules.html) for Kbuild

> The above line can be put in either a “Kbuild” file or a “Makefile.”

According to GNU Make's [manual](https://www.gnu.org/software/make/manual/make.html)

> By default, when make looks for the makefile, it tries the following names, in order: GNUmakefile, makefile and Makefile.

In this [SO](https://stackoverflow.com/questions/57228873/the-difference-between-mk-file-and-makefile) answer

> The .mk extension is a more or less standard extension for make files that have other names than the defaults.