### PR TITLE
Add firebase as a folder name 

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -607,7 +607,7 @@ export const folderIcons: FolderTheme[] = [
         folderNames: ['mobile', 'mobiles', 'portable', 'portability'],
       },
       { name: 'folder-stencil', folderNames: ['.stencil'] },
-      { name: 'folder-firebase', folderNames: ['.firebase'] },
+      { name: 'folder-firebase', folderNames: ['firebase','.firebase'] },
       { name: 'folder-svelte', folderNames: ['svelte', '.svelte-kit'] },
       {
         name: 'folder-update',


### PR DESCRIPTION
While .firebase is the configuration folder for firebase, it is common for projects that use firebase to have a folder called "firebase" that contains code for the authentication, firestore code and other utilities.  

Again, thank you for making all the icons and folders look awesome! 