### PR TITLE
feat: psv alias

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -243,7 +243,7 @@ export const fileIcons: FileIcons = {
       fileNames: ['astro.config.js', 'astro.config.mjs', 'astro.config.cjs'],
     },
     { name: 'pdf', fileExtensions: ['pdf'] },
-    { name: 'table', fileExtensions: ['xlsx', 'xls', 'csv', 'tsv'] },
+    { name: 'table', fileExtensions: ['xlsx', 'xls', 'csv', 'tsv', 'psv'] },
     {
       name: 'vscode',
       fileExtensions: [

--- a/src/icons/languageIcons.ts
+++ b/src/icons/languageIcons.ts
@@ -87,7 +87,7 @@ export const languageIcons: LanguageIcon[] = [
   { icon: { name: 'salesforce' }, ids: ['apex'] },
   { icon: { name: 'sas' }, ids: ['sas'] },
   { icon: { name: 'docker' }, ids: ['dockerfile'] },
-  { icon: { name: 'table' }, ids: ['csv', 'tsv'] },
+  { icon: { name: 'table' }, ids: ['csv', 'tsv', 'psv'] },
   { icon: { name: 'csharp' }, ids: ['csharp'] },
   { icon: { name: 'console' }, ids: ['bat', 'awk', 'shellscript'] },
   { icon: { name: 'cpp' }, ids: ['cpp'] },


### PR DESCRIPTION
Hello,

I suggest psv (Pipe Separated Values) should be rendering the table icon.
As pipes are not often used in the data, .psv files are useful for this type of structure.

Thanks