### PR TITLE
Add file name `commit'msg` to display `console` icon

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -353,7 +353,7 @@ export const fileIcons: FileIcons = {
         'fish',
         'exp',
       ],
-      fileNames: ['pre-commit', 'pre-push', 'post-merge'],
+      fileNames: ['commit-msg', 'pre-commit', 'pre-push', 'post-merge'],
     },
     {
       name: 'powershell',


### PR DESCRIPTION
This PR simply add file name `commit-msg` to the patterns to display the `console` icon. 

This name aligns with others already listed, commonly used in [git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) management libraries like `hysky` (JS). So this PR should reinforce consistency within files with the same type and nature.

![image](https://user-images.githubusercontent.com/44725817/160222816-df7f6dc6-85fb-4b4a-bf4c-1ffb3d42251d.png)
