### PR TITLE
feat: Bazel icon for WORKSPACE and BUILD files

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1393,7 +1393,7 @@ export const fileIcons: FileIcons = {
     {
       name: 'bazel',
       fileExtensions: ['bzl', 'bazel'],
-      fileNames: ['.bazelignore', '.bazelrc', '.bazelversion'],
+      fileNames: ['.bazelignore', '.bazelrc', '.bazelversion', 'WORKSPACE', 'BUILD'],
     },
     { name: 'mint', fileExtensions: ['mint'] },
     { name: 'velocity', fileExtensions: ['vm', 'fhtml', 'vtl'] },


### PR DESCRIPTION
This just applies the Bazel icon to WORKSPACE and BUILD files
Reference:

- https://bazel.build/concepts/build-ref
- https://bazel.build/concepts/build-files