### PR TITLE
Add gulpfile.ts etc. as folder names

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -397,7 +397,13 @@ export const folderIcons: FolderTheme[] = [
       { name: 'folder-less', folderNames: ['less'] },
       {
         name: 'folder-gulp',
-        folderNames: ['gulp'],
+        folderNames: [
+          'gulp',
+          'gulpfile.js',
+          'gulpfile.mjs',
+          'gulpfile.ts',
+          'gulpfile.babel.js',
+        ],
       },
       {
         name: 'folder-python',


### PR DESCRIPTION
As per [Gulp Docs](https://gulpjs.com/docs/en/getting-started/javascript-and-gulpfiles#splitting-a-gulpfile), every file name is also a valid folder name if it contains an index file.