### PR TITLE
feat: add go.work.sum to list of go-mod files

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -340,7 +340,10 @@ export const fileIcons: FileIcons = {
       fileExtensions: ['hh', 'hpp', 'hxx', 'h++', 'hp', 'tcc', 'inl'],
     },
     { name: 'go', fileExtensions: ['go'] },
-    { name: 'go-mod', fileNames: ['go.mod', 'go.sum', 'go.work', 'go.work.sum'] },
+    {
+      name: 'go-mod',
+      fileNames: ['go.mod', 'go.sum', 'go.work', 'go.work.sum'],
+    },
     { name: 'python', fileExtensions: ['py'] },
     {
       name: 'python-misc',

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -340,7 +340,7 @@ export const fileIcons: FileIcons = {
       fileExtensions: ['hh', 'hpp', 'hxx', 'h++', 'hp', 'tcc', 'inl'],
     },
     { name: 'go', fileExtensions: ['go'] },
-    { name: 'go-mod', fileNames: ['go.mod', 'go.sum', 'go.work'] },
+    { name: 'go-mod', fileNames: ['go.mod', 'go.sum', 'go.work', 'go.work.sum'] },
     { name: 'python', fileExtensions: ['py'] },
     {
       name: 'python-misc',


### PR DESCRIPTION
I was unable to find a template to use, so forgive me if I'm not following the correct format. The link below provides information on `go.work.sum`. It should have been added with `go.work` back in February.

https://go.googlesource.com/proposal/+/master/design/45713-workspace.md#files