### PR TITLE
Associate XLSM with "Table" icon

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -254,7 +254,7 @@ export const fileIcons: FileIcons = {
     { name: 'pdf', fileExtensions: ['pdf'] },
     {
       name: 'table',
-      fileExtensions: ['xlsx', 'xls', 'csv', 'tsv', 'psv', 'ods'],
+      fileExtensions: ['xlsx', 'xlsm', 'xls', 'csv', 'tsv', 'psv', 'ods'],
     },
     {
       name: 'vscode',


### PR DESCRIPTION
Macro-enabled excel format. closes #1493

Though i was wondering: would it be better to make it a specific icon for macro enabled sheet as a spinoff of the table icon?
Maybe by adding the "Script" material icon to the corner.