### PR TITLE
feat: Support Playwright component test config files

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -48,7 +48,14 @@ export const fileIcons: FileIcons = {
     { name: 'proto', fileExtensions: ['proto'] },
     {
       name: 'playwright',
-      fileNames: ['playwright.config.js', 'playwright.config.ts'],
+      fileNames: [
+        'playwright.config.js',
+        'playwright.config.mjs',
+        'playwright.config.ts',
+        'playwright-ct.config.js',
+        'playwright-ct.config.mjs',
+        'playwright-ct.config.ts',
+      ],
     },
     {
       name: 'sublime',


### PR DESCRIPTION
Now that Playwright supports component testing
(https://github.com/microsoft/playwright/releases/tag/v1.22.0), this
commit adds the canonical config filenames. It also includes the '.mjs'
extension.