### PR TITLE
Adds Cypress 10.x e2e extension

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -2032,7 +2032,10 @@ export const fileIcons: FileIcons = {
       ],
     },
     { name: 'rome', fileNames: ['rome.json'] },
-    { name: 'cypress', fileNames: ['cypress.json', 'cypress.env.json', 'cypress.config.ts'] },
+    {
+      name: 'cypress',
+      fileNames: ['cypress.json', 'cypress.env.json', 'cypress.config.ts'],
+    },
     { name: 'siyuan', fileExtensions: ['sy'] },
     { name: 'ndst', fileExtensions: ['ndst.yml', 'ndst.yaml', 'ndst.json'] },
     { name: 'plop', fileNames: ['plopfile.js', 'plopfile.ts'] },

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -688,6 +688,7 @@ export const fileIcons: FileIcons = {
         'spec.ts',
         'spec.cts',
         'spec.mts',
+        'e2e.cy.ts',
         'e2e-spec.ts',
         'e2e-spec.cts',
         'e2e-spec.mts',

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -2031,7 +2031,7 @@ export const fileIcons: FileIcons = {
       ],
     },
     { name: 'rome', fileNames: ['rome.json'] },
-    { name: 'cypress', fileNames: ['cypress.json', 'cypress.env.json'] },
+    { name: 'cypress', fileNames: ['cypress.json', 'cypress.env.json', 'cypress.config.ts'] },
     { name: 'siyuan', fileExtensions: ['sy'] },
     { name: 'ndst', fileExtensions: ['ndst.yml', 'ndst.yaml', 'ndst.json'] },
     { name: 'plop', fileNames: ['plopfile.js', 'plopfile.ts'] },

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -689,6 +689,7 @@ export const fileIcons: FileIcons = {
         'spec.cts',
         'spec.mts',
         'e2e.cy.ts',
+        'e2e.cy.js',
         'e2e-spec.ts',
         'e2e-spec.cts',
         'e2e-spec.mts',


### PR DESCRIPTION
As of Cypress 10.x E2E specs have the "e2e.cy.ts" file extension.

To make Material Icon detect these as E2E Files and not as plain .ts Files I added the cypress specific handle to fileIcons.ts

Please review