### PR TITLE
Add Support for `.d.cts` and `.d.mts` Files

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -246,7 +246,10 @@ export const fileIcons: FileIcons = {
         '.clang-tidy',
       ],
     },
-    { name: 'typescript-def', fileExtensions: ['d.ts'] },
+    {
+      name: 'typescript-def',
+      fileExtensions: ['d.ts', 'd.cts', 'd.mts'],
+    },
     { name: 'markojs', fileExtensions: ['marko'] },
     {
       name: 'astro',


### PR DESCRIPTION
In my last PR, #1541, I mistakingly forgot to add support for `.d.cts` and `.d.mts` files as well.
Changes made in this PR will provide support for said files.