### PR TITLE
[Add] Cypress file name "cypress.config.js" in fileIcon.ts

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -2038,7 +2038,12 @@ export const fileIcons: FileIcons = {
     { name: 'rome', fileNames: ['rome.json'] },
     {
       name: 'cypress',
-      fileNames: ['cypress.json', 'cypress.env.json', 'cypress.config.ts'],
+      fileNames: [
+        'cypress.json',
+        'cypress.env.json',
+        'cypress.config.ts',
+        'cypress.config.js',
+      ],
     },
     { name: 'siyuan', fileExtensions: ['sy'] },
     { name: 'ndst', fileExtensions: ['ndst.yml', 'ndst.yaml', 'ndst.json'] },


### PR DESCRIPTION
- Add missing js extension in Cypress fileNames
- Reference "https://docs.cypress.io/guides/references/migration-guide#Configuration-File-Changes"