### PR TITLE
fix: added integration-tests folder

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -343,6 +343,8 @@ export const folderIcons: FolderTheme[] = [
           'it',
           'integration-test',
           'integration-tests',
+          '__integration-test__',
+          '__integration-tests__',
         ],
       },
       {


### PR DESCRIPTION
This PR adds `__integration-test__` and `__integration-tests__` folder names to the `folder-coverage` icon.