### PR TITLE
feat: Added `wgsl` extension

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -2011,6 +2011,7 @@ export const fileIcons: FileIcons = {
         'geom.hlsl',
         'comp.hlsl',
         'tess.hlsl',
+        'wgsl',
       ],
     },
     {

--- a/src/icons/languageIcons.ts
+++ b/src/icons/languageIcons.ts
@@ -132,5 +132,5 @@ export const languageIcons: LanguageIcon[] = [
   { icon: { name: 'gemini' }, ids: ['gemini', 'text-gemini'] },
   { icon: { name: 'vlang' }, ids: ['v'] },
   { icon: { name: 'wolframlanguage' }, ids: ['wolfram'] },
-  { icon: { name: 'shader' }, ids: ['hlsl', 'glsl'] },
+  { icon: { name: 'shader' }, ids: ['hlsl', 'glsl', 'wgsl'] },
 ];


### PR DESCRIPTION
[WGSL](https://gpuweb.github.io/gpuweb/wgsl/) is a shader language, like GLSL or HLSL, but more cross-platform, built for [WebGPU](https://en.wikipedia.org/wiki/WebGPU). I just added it as an extension for shaders.