### PR TITLE
feat(dependabot): Add missing filename dependabot.yaml

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1861,7 +1861,7 @@ export const fileIcons: FileIcons = {
     { name: 'lolcode', fileExtensions: ['lol'] },
     { name: 'idris', fileExtensions: ['idr', 'ibc'] },
     { name: 'quasar', fileNames: ['quasar.conf.js', 'quasar.config.js'] },
-    { name: 'dependabot', fileNames: ['dependabot.yml'] },
+    { name: 'dependabot', fileNames: ['dependabot.yml', 'dependabot.yaml'] },
     { name: 'pipeline', fileExtensions: ['pipeline'] },
     {
       name: 'vite',


### PR DESCRIPTION
Currently the icon `dependabot` is only mapped to the file extension 
`dependabot.yml`, but Dependabot supports both `.yaml` and `.yml`. 
Tested this personally and it is also documented in various issues in the 
Dependabot repos. For example [here](https://github.com/dependabot/feedback/issues/874).

Fixes <https://github.com/PKief/vscode-material-icon-theme/issues/1745>