### PR TITLE
Adds default filename for stylelint cache file

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1355,6 +1355,7 @@ export const fileIcons: FileIcons = {
         '.stylelintrc.js',
         '.stylelintrc.cjs',
         '.stylelintignore',
+        '.stylelintcache',
       ],
       light: true,
     },


### PR DESCRIPTION
Adds `.stylelintcache` to list of stylelint names.

This file-ending corresponds to the default filename for cache files created from running stylelint with flag `--cache`.
More info in their docs: https://stylelint.io/user-guide/usage/options/#cache