### PR TITLE
feat: Add support for Gatsby config typescript files

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1444,8 +1444,11 @@ export const fileIcons: FileIcons = {
         'gatsby-config.ts',
         'gatsby-config.js',
         'gatsby-node.js',
+        'gatsby-node.ts',
         'gatsby-browser.js',
+        'gatsby-browser.tsx',
         'gatsby-ssr.js',
+        'gatsby-ssr.tsx',
       ],
     },
     {


### PR DESCRIPTION
Add Gatsby icon to newly supported typescript files.
- https://www.gatsbyjs.com/docs/how-to/custom-configuration/typescript/#gatsby-browsertsx--gatsby-ssrtsx
- https://www.gatsbyjs.com/docs/how-to/custom-configuration/typescript/#gatsby-configts
- https://www.gatsbyjs.com/docs/how-to/custom-configuration/typescript/#gatsby-nodets