### PR TITLE
Added file association to docker-compose file extension

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -471,7 +471,7 @@ export const fileIcons: FileIcons = {
     { name: 'arduino', fileExtensions: ['ino'] },
     {
       name: 'docker',
-      fileExtensions: ['dockerignore', 'dockerfile'],
+      fileExtensions: ['dockerignore', 'dockerfile', 'docker-compose.yml', 'docker-compose.yaml'],
       fileNames: [
         'dockerfile',
         'dockerfile.prod',


### PR DESCRIPTION
Added file extension associations for docker-compose in response to #1705 for *.docker-compose.yaml and *.docker-compose.yml to receive the docker icon