### PR TITLE
Associate `.mcpack` and `.mcaddon` files with Minecraft file icon

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1859,6 +1859,8 @@ export const fileIcons: FileIcons = {
         'mine',
         'mus',
         'mcstructure',
+        'mcpack',
+        'mcaddon',
       ],
       fileNames: ['.mcattributes', '.mcdefinitions', '.mcignore'],
     },


### PR DESCRIPTION
Fixes #1731