### PR TITLE
change error messages for Opacity and Saturation (value should be float)

### DIFF
--- a/src/i18n/lang-en.ts
+++ b/src/i18n/lang-en.ts
@@ -1,43 +1,43 @@
-import { Translation } from "../models";
+import { Translation } from '../models';
 
 export const translation: Translation = {
-	activate: "Activate",
-	activated: "Material Icon Theme is active.",
-	iconPacks: {
-		selectPack: "Select an icon pack",
-		description: "Select the '%0' icon pack",
-		disabled: "Disable icon packs",
-	},
-	folders: {
-		toggleIcons: "Pick a folder theme",
-		color: "Choose a folder color",
-		hexCode: "Insert a HEX color code",
-		wrongHexCode: "Invalid HEX color code!",
-		disabled: "No folder icons",
-		theme: {
-			description: "Select the '%0' folder theme",
-		},
-	},
-	opacity: {
-		inputPlaceholder: "Opacity value (between 0 and 1)",
-		wrongValue: "Please enter a floating-point number between 0 and 1.",
-	},
-	toggleSwitch: {
-		on: "ON",
-		off: "OFF",
-	},
-	explorerArrows: {
-		toggle: "Toggle folder arrows",
-		enable: "Show folder arrows",
-		disable: "Hide folder arrows",
-	},
-	grayscale: {
-		toggle: "Toggle grayscale icons",
-		enable: "Enable grayscale icons",
-		disable: "Disable grayscale icons",
-	},
-	saturation: {
-		inputPlaceholder: "Saturation value (between 0 and 1)",
-		wrongValue: "Please enter a floating-point number between 0 and 1.",
-	},
+  activate: 'Activate',
+  activated: 'Material Icon Theme is active.',
+  iconPacks: {
+    selectPack: 'Select an icon pack',
+    description: "Select the '%0' icon pack",
+    disabled: 'Disable icon packs',
+  },
+  folders: {
+    toggleIcons: 'Pick a folder theme',
+    color: 'Choose a folder color',
+    hexCode: 'Insert a HEX color code',
+    wrongHexCode: 'Invalid HEX color code!',
+    disabled: 'No folder icons',
+    theme: {
+      description: "Select the '%0' folder theme",
+    },
+  },
+  opacity: {
+    inputPlaceholder: 'Opacity value (between 0 and 1)',
+    wrongValue: 'Please enter a floating-point number between 0 and 1.',
+  },
+  toggleSwitch: {
+    on: 'ON',
+    off: 'OFF',
+  },
+  explorerArrows: {
+    toggle: 'Toggle folder arrows',
+    enable: 'Show folder arrows',
+    disable: 'Hide folder arrows',
+  },
+  grayscale: {
+    toggle: 'Toggle grayscale icons',
+    enable: 'Enable grayscale icons',
+    disable: 'Disable grayscale icons',
+  },
+  saturation: {
+    inputPlaceholder: 'Saturation value (between 0 and 1)',
+    wrongValue: 'Please enter a floating-point number between 0 and 1.',
+  },
 };

--- a/src/i18n/lang-en.ts
+++ b/src/i18n/lang-en.ts
@@ -1,43 +1,43 @@
-import { Translation } from '../models';
+import { Translation } from "../models";
 
 export const translation: Translation = {
-  activate: 'Activate',
-  activated: 'Material Icon Theme is active.',
-  iconPacks: {
-    selectPack: 'Select an icon pack',
-    description: "Select the '%0' icon pack",
-    disabled: 'Disable icon packs',
-  },
-  folders: {
-    toggleIcons: 'Pick a folder theme',
-    color: 'Choose a folder color',
-    hexCode: 'Insert a HEX color code',
-    wrongHexCode: 'Invalid HEX color code!',
-    disabled: 'No folder icons',
-    theme: {
-      description: "Select the '%0' folder theme",
-    },
-  },
-  opacity: {
-    inputPlaceholder: 'Opacity value (between 0 and 1)',
-    wrongValue: 'The value must be between 0 and 1!',
-  },
-  toggleSwitch: {
-    on: 'ON',
-    off: 'OFF',
-  },
-  explorerArrows: {
-    toggle: 'Toggle folder arrows',
-    enable: 'Show folder arrows',
-    disable: 'Hide folder arrows',
-  },
-  grayscale: {
-    toggle: 'Toggle grayscale icons',
-    enable: 'Enable grayscale icons',
-    disable: 'Disable grayscale icons',
-  },
-  saturation: {
-    inputPlaceholder: 'Saturation value (between 0 and 1)',
-    wrongValue: 'The value must be between 0 and 1!',
-  },
+	activate: "Activate",
+	activated: "Material Icon Theme is active.",
+	iconPacks: {
+		selectPack: "Select an icon pack",
+		description: "Select the '%0' icon pack",
+		disabled: "Disable icon packs",
+	},
+	folders: {
+		toggleIcons: "Pick a folder theme",
+		color: "Choose a folder color",
+		hexCode: "Insert a HEX color code",
+		wrongHexCode: "Invalid HEX color code!",
+		disabled: "No folder icons",
+		theme: {
+			description: "Select the '%0' folder theme",
+		},
+	},
+	opacity: {
+		inputPlaceholder: "Opacity value (between 0 and 1)",
+		wrongValue: "Please enter a floating-point number between 0 and 1.",
+	},
+	toggleSwitch: {
+		on: "ON",
+		off: "OFF",
+	},
+	explorerArrows: {
+		toggle: "Toggle folder arrows",
+		enable: "Show folder arrows",
+		disable: "Hide folder arrows",
+	},
+	grayscale: {
+		toggle: "Toggle grayscale icons",
+		enable: "Enable grayscale icons",
+		disable: "Disable grayscale icons",
+	},
+	saturation: {
+		inputPlaceholder: "Saturation value (between 0 and 1)",
+		wrongValue: "Please enter a floating-point number between 0 and 1.",
+	},
 };


### PR DESCRIPTION
This PR suggests changes to the wording of the error messages when the user attempts to set the values for Opacity or Saturation. The previous wording didn’t make it clear, imo, that the value can be a floating-point number. I went to experiment with these settings and initially thought I could only enter a `1` or a `0` (then wondered why they weren’t Boolean).