### PR TITLE
harmonise/clarify wording of Toggle Explorer Arrows

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ With the following configuration you can customize the language icons. It is als
 
 Available language ids:
 
-https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers
+<https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers>
 
 You can see the available icon names in the overview above.
 
@@ -177,10 +177,10 @@ Press `Ctrl-Shift-P` to open the command palette and type `Material Icons`.
 | **Change Folder Theme**           | Change the design of the folder icons.                                             |
 | **Change Opacity**                | Change the opacity of the icons.                                                   |
 | **Change Saturation**             | Change the saturation value of the icons.                                          |
-| **Configure Icon Packs**          | Select an icon pack that enables additional icons (e.g. for Angular, React, Ngrx). |
-| **Hide Folder Arrows**            | Hides the arrows next to the folder icons.                                         |
-| **Restore Default Configuration** | Reset the default configurations of the icon theme.                                |
-| **Toggle Grayscale**              | Sets the saturation of the icons to zero, so that they are grayscale.              |
+| **Configure Icon Packs**          | Selects an icon pack that enables additional icons (e.g. for Angular, React, Ngrx).|
+| **Toggle Explorer Arrows**        | Show or hide the arrows next to the folder icons.                                  |
+| **Restore Default Configuration** | Reset to the default configuration.                                                |
+| **Toggle Grayscale**              | Set icon saturation to `0` (grayscale), or `1` (colour).                           |
 
 ## Icon sources
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Press `Ctrl-Shift-P` to open the command palette and type `Material Icons`.
 | **Configure Icon Packs**          | Selects an icon pack that enables additional icons (e.g. for Angular, React, Ngrx).|
 | **Toggle Explorer Arrows**        | Show or hide the arrows next to the folder icons.                                  |
 | **Restore Default Configuration** | Reset to the default configuration.                                                |
-| **Toggle Grayscale**              | Set icon saturation to `0` (grayscale), or `1` (colour).                           |
+| **Toggle Grayscale**              | Set icon saturation to `0` (grayscale), or `1` (color).                           |
 
 ## Icon sources
 

--- a/src/i18n/lang-en.ts
+++ b/src/i18n/lang-en.ts
@@ -1,43 +1,43 @@
-import { Translation } from "../models";
+import { Translation } from '../models';
 
 export const translation: Translation = {
-	activate: "Activate",
-	activated: "Material Icon Theme is active.",
-	iconPacks: {
-		selectPack: "Select an icon pack",
-		description: "Select the '%0' icon pack",
-		disabled: "Disable icon packs",
-	},
-	folders: {
-		toggleIcons: "Pick a folder theme",
-		color: "Choose a folder color",
-		hexCode: "Insert a HEX color code",
-		wrongHexCode: "Invalid HEX color code!",
-		disabled: "No folder icons",
-		theme: {
-			description: "Select the '%0' folder theme",
-		},
-	},
-	opacity: {
-		inputPlaceholder: "Opacity value (between 0 and 1)",
-		wrongValue: "The value must be between 0 and 1!",
-	},
-	toggleSwitch: {
-		on: "ON",
-		off: "OFF",
-	},
-	explorerArrows: {
-		toggle: "Toggle folder arrows in Explorer",
-		enable: "Show folder arrows in Explorer",
-		disable: "Hide folder arrows in Explorer",
-	},
-	grayscale: {
-		toggle: "Toggle grayscale icons",
-		enable: "Enable grayscale icons",
-		disable: "Disable grayscale icons",
-	},
-	saturation: {
-		inputPlaceholder: "Saturation value (between 0 and 1)",
-		wrongValue: "The value must be between 0 and 1!",
-	},
+  activate: 'Activate',
+  activated: 'Material Icon Theme is active.',
+  iconPacks: {
+    selectPack: 'Select an icon pack',
+    description: "Select the '%0' icon pack",
+    disabled: 'Disable icon packs',
+  },
+  folders: {
+    toggleIcons: 'Pick a folder theme',
+    color: 'Choose a folder color',
+    hexCode: 'Insert a HEX color code',
+    wrongHexCode: 'Invalid HEX color code!',
+    disabled: 'No folder icons',
+    theme: {
+      description: "Select the '%0' folder theme",
+    },
+  },
+  opacity: {
+    inputPlaceholder: 'Opacity value (between 0 and 1)',
+    wrongValue: 'The value must be between 0 and 1!',
+  },
+  toggleSwitch: {
+    on: 'ON',
+    off: 'OFF',
+  },
+  explorerArrows: {
+    toggle: 'Toggle folder arrows in Explorer',
+    enable: 'Show folder arrows in Explorer',
+    disable: 'Hide folder arrows in Explorer',
+  },
+  grayscale: {
+    toggle: 'Toggle grayscale icons',
+    enable: 'Enable grayscale icons',
+    disable: 'Disable grayscale icons',
+  },
+  saturation: {
+    inputPlaceholder: 'Saturation value (between 0 and 1)',
+    wrongValue: 'The value must be between 0 and 1!',
+  },
 };

--- a/src/i18n/lang-en.ts
+++ b/src/i18n/lang-en.ts
@@ -1,43 +1,43 @@
-import { Translation } from '../models';
+import { Translation } from "../models";
 
 export const translation: Translation = {
-  activate: 'Activate',
-  activated: 'Material Icon Theme is active.',
-  iconPacks: {
-    selectPack: 'Select an icon pack',
-    description: "Select the '%0' icon pack",
-    disabled: 'Disable icon packs',
-  },
-  folders: {
-    toggleIcons: 'Pick a folder theme',
-    color: 'Choose a folder color',
-    hexCode: 'Insert a HEX color code',
-    wrongHexCode: 'Invalid HEX color code!',
-    disabled: 'No folder icons',
-    theme: {
-      description: "Select the '%0' folder theme",
-    },
-  },
-  opacity: {
-    inputPlaceholder: 'Opacity value (between 0 and 1)',
-    wrongValue: 'The value must be between 0 and 1!',
-  },
-  toggleSwitch: {
-    on: 'ON',
-    off: 'OFF',
-  },
-  explorerArrows: {
-    toggle: 'Toggle folder arrows',
-    enable: 'Show folder arrows',
-    disable: 'Hide folder arrows',
-  },
-  grayscale: {
-    toggle: 'Toggle grayscale icons',
-    enable: 'Enable grayscale icons',
-    disable: 'Disable grayscale icons',
-  },
-  saturation: {
-    inputPlaceholder: 'Saturation value (between 0 and 1)',
-    wrongValue: 'The value must be between 0 and 1!',
-  },
+	activate: "Activate",
+	activated: "Material Icon Theme is active.",
+	iconPacks: {
+		selectPack: "Select an icon pack",
+		description: "Select the '%0' icon pack",
+		disabled: "Disable icon packs",
+	},
+	folders: {
+		toggleIcons: "Pick a folder theme",
+		color: "Choose a folder color",
+		hexCode: "Insert a HEX color code",
+		wrongHexCode: "Invalid HEX color code!",
+		disabled: "No folder icons",
+		theme: {
+			description: "Select the '%0' folder theme",
+		},
+	},
+	opacity: {
+		inputPlaceholder: "Opacity value (between 0 and 1)",
+		wrongValue: "The value must be between 0 and 1!",
+	},
+	toggleSwitch: {
+		on: "ON",
+		off: "OFF",
+	},
+	explorerArrows: {
+		toggle: "Toggle folder arrows in Explorer",
+		enable: "Show folder arrows in Explorer",
+		disable: "Hide folder arrows in Explorer",
+	},
+	grayscale: {
+		toggle: "Toggle grayscale icons",
+		enable: "Enable grayscale icons",
+		disable: "Disable grayscale icons",
+	},
+	saturation: {
+		inputPlaceholder: "Saturation value (between 0 and 1)",
+		wrongValue: "The value must be between 0 and 1!",
+	},
 };


### PR DESCRIPTION
This PR sets the wording of Toggle Explorer Arrows to be more explicit. It also makes minor clarifying changes to wording of some descriptions in the Commands section of README.md.

Successfully merging it would require re-doing the Commands screenshot at
https://github.com/PKief/vscode-material-icon-theme/blob/5e57ec33d3402f325b3e711a6eb34bc3b90c2b1c/README.md?plain=1#L169
