### PR TITLE
feat: 🎨 add console icon for nushell

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -386,6 +386,7 @@ export const fileIcons: FileIcons = {
         'awk',
         'fish',
         'exp',
+        'nu',
       ],
       fileNames: ['commit-msg', 'pre-commit', 'pre-push', 'post-merge'],
     },


### PR DESCRIPTION
A very simple PR to add [nushell](https://github.com/nushell/nushell)'s `nu` files to the `console` family

- **Before**:
 ![image](https://user-images.githubusercontent.com/7041726/200144006-a80a5d0f-6848-446f-a3d3-ac7cd74a25e4.png)

- **After**:
 ![image](https://user-images.githubusercontent.com/7041726/200144034-5492590c-c6bf-4129-ad27-8908f57cda41.png)
