### PR TITLE
Add .cjs extension to `graphql.config`

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -604,6 +604,7 @@ export const fileIcons: FileIcons = {
         '.graphqlrc.yml',
         'graphql.config.json',
         'graphql.config.js',
+        'graphql.config.cjs',
         'graphql.config.ts',
         'graphql.config.toml',
         'graphql.config.yaml',


### PR DESCRIPTION
Icon already supported for `.graphqlrc.cjs`, but not for `graphql.config.cjs`, according [graphql config docs](https://the-guild.dev/graphql/config/docs#graphqlconfigjs-or-graphqlrcjs) they are same