### PR TITLE
Add .cjs and .mjs extensions to `plop` fileNames

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -2135,7 +2135,10 @@ export const fileIcons: FileIcons = {
     },
     { name: 'siyuan', fileExtensions: ['sy'] },
     { name: 'ndst', fileExtensions: ['ndst.yml', 'ndst.yaml', 'ndst.json'] },
-    { name: 'plop', fileNames: ['plopfile.js', 'plopfile.ts'] },
+    {
+      name: 'plop',
+      fileNames: ['plopfile.js', 'plopfile.cjs', 'plopfile.mjs', 'plopfile.ts'],
+    },
     { name: 'tobi', fileExtensions: ['tobi'] },
     { name: 'tobimake', fileNames: ['.tobimake'] },
     { name: 'gleam', fileNames: ['gleam.toml'], fileExtensions: ['gleam'] },


### PR DESCRIPTION
According [plop docs](https://plopjs.com/documentation/#3-create-a-plopfilejs-at-the-root-of-your-project) plopfile has support for `.cjs` and `.mjs` extensions