### PR TITLE
feat #1840: fix issue

### DIFF
--- a/src/icons/generator/constants.ts
+++ b/src/icons/generator/constants.ts
@@ -26,4 +26,4 @@ export const highContrastColorFileEnding: string = '_highContrast';
 /**
  * Pattern to match wildcards for custom file icon mappings.
  */
-export const wildcardPattern = new RegExp(/^\*{1,2}\./);
+export const wildcardPattern = new RegExp(/^\*{1,2}(.|_)/);


### PR DESCRIPTION
what was missing?

- willcardPattern only. could distinguish. In languages like Golang, test files are parsed by the language server with `_test.`. `_test` support was missing in material icon theme.

What has been added?

- Added `_test` icon for Golang. Users can add their own icons with the custom icon `**_test.go` key.

Before:

```json
  "material-icon-theme.files.associations": {
    "**_test.go": "../../icons/test_go" // not working
  }
```

After:

```json
  "material-icon-theme.files.associations": {
    "**_test.go": "../../icons/test_go" // working
  }
```

Learn more with the _test pattern in Golang:

![Screenshot 2023-01-28 at 12 43 08](https://user-images.githubusercontent.com/76786120/215259529-ab064f91-2cf2-4861-b120-ac8ed1578ae5.png)

https://pkg.go.dev/testing