### PR TITLE
add filename .env.prd into tune icon

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1156,6 +1156,7 @@ export const fileIcons: FileIcons = {
         '.env.staging.local',
         '.env.test.local',
         '.env.uat',
+        '.env.prd',
       ],
     },
     {


### PR DESCRIPTION
Hi @PKief ,

![image](https://user-images.githubusercontent.com/33013947/217882140-957bb3e8-bfd8-4d83-b623-1ed8d234830d.png)
I would like to add **.env.prd** into **tune icon**, this is because my current company like to keep character length same as **.env.uat** show in above screenshot.