### PR TITLE
Expand godot-assets associations

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1613,7 +1613,7 @@ export const fileIcons: FileIcons = {
     { name: 'mint', fileExtensions: ['mint'] },
     { name: 'velocity', fileExtensions: ['vm', 'fhtml', 'vtl'] },
     { name: 'godot', fileExtensions: ['gd'] },
-    { name: 'godot-assets', fileExtensions: ['godot', 'tres', 'tscn'] },
+    { name: 'godot-assets', fileExtensions: ['godot', 'tres', 'tscn', 'gdns'] },
     {
       name: 'azure-pipelines',
       fileNames: ['azure-pipelines.yml', 'azure-pipelines.yaml'],

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1613,7 +1613,18 @@ export const fileIcons: FileIcons = {
     { name: 'mint', fileExtensions: ['mint'] },
     { name: 'velocity', fileExtensions: ['vm', 'fhtml', 'vtl'] },
     { name: 'godot', fileExtensions: ['gd'] },
-    { name: 'godot-assets', fileExtensions: ['godot', 'tres', 'tscn', 'gdns'] },
+    {
+      name: 'godot-assets',
+      fileExtensions: [
+        'godot',
+        'tres',
+        'tscn',
+        'gdns',
+        'gdnlib',
+        'gdshader',
+        'gdextension',
+      ],
+    },
     {
       name: 'azure-pipelines',
       fileNames: ['azure-pipelines.yml', 'azure-pipelines.yaml'],

--- a/src/icons/languageIcons.ts
+++ b/src/icons/languageIcons.ts
@@ -77,6 +77,7 @@ export const languageIcons: LanguageIcon[] = [
   { icon: { name: 'django' }, ids: ['django-html', 'django-txt'] },
   { icon: { name: 'html' }, ids: ['html'] },
   { icon: { name: 'godot' }, ids: ['gdscript'] },
+  { icon: { name: 'godot-assets' }, ids: ['gdresource', 'gdshader'] },
   { icon: { name: 'vim' }, ids: ['viml'] },
   { icon: { name: 'silverstripe' }, ids: [] },
   { icon: { name: 'prolog' }, ids: ['prolog'] },


### PR DESCRIPTION
Added extra extension to godot-assets icon to handle a typical [GDNative file structure](https://docs.godotengine.org/en/stable/tutorials/scripting/gdnative/gdnative_cpp_example.html)