### PR TITLE
Gatsby - add new supported file extensions

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1487,9 +1487,11 @@ export const fileIcons: FileIcons = {
     {
       name: 'gatsby',
       fileNames: [
-        'gatsby-config.ts',
         'gatsby-config.js',
+        'gatsby-config.mjs',
+        'gatsby-config.ts',
         'gatsby-node.js',
+        'gatsby-node.mjs',
         'gatsby-node.ts',
         'gatsby-browser.js',
         'gatsby-browser.tsx',


### PR DESCRIPTION
Gatsby 5.3+ officially supports ESM with the `gatsby-config` and `gatsby-node` files, but they require an `mjs` extension.

Sources:

- https://www.gatsbyjs.com/docs/reference/release-notes/v5.3/#es-modules-esm-in-gatsby-files
- https://github.com/vscode-icons/vscode-icons/pull/3204
