### PR TITLE
feat: enhance ESLint flat config support

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1351,6 +1351,7 @@ export const fileIcons: FileIcons = {
         '.eslintignore',
         '.eslintcache',
         'eslint.config.js',
+        'eslint.config.mjs',
       ],
     },
     {


### PR DESCRIPTION
The config file can be overrides with `-c, --config` option.
Using a `.mjs` config file let Node treating it as an ECMAScript module where you can use ESM syntax rather than set `"type": "module"` in `package.json`.

Refs:

- [Configuration File Resolution](https://eslint.org/docs/latest/use/configure/configuration-files-new#configuration-file-resolution)