### PR TITLE
feat: support TSConfig icon for paths file

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -2094,6 +2094,7 @@ export const fileIcons: FileIcons = {
         'tsconfig.esm.json',
         'tsconfig.mjs.json',
         'tsconfig.doc.json',
+        'tsconfig.paths.json'
       ],
       fileExtensions: ['tsconfig.json'],
     },


### PR DESCRIPTION
Need to support `tsconfig.paths.json` file to have the TSConfig icon. This file is useful to declare the `paths`:
```json
{
	"compilerOptions": {
		"paths": {
			"@/utils/*": ["src/utils/*"],
			"@/constants/*": ["src/constants/*"],
			"@/models/*": ["src/models/*"],
			"@/interfaces/*": ["src/interfaces/*"],
			"@/validators/*": ["src/validators/*"],
			"@/pipes/*": ["src/pipes/*"]
		}
	}
}
```