### PR TITLE
feat: support CommonJS file for semantic release

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1644,6 +1644,7 @@ export const fileIcons: FileIcons = {
         '.releaserc.json',
         '.releaserc.js',
         'release.config.js',
+        'release.config.cjs',
       ],
     },
     {


### PR DESCRIPTION
Support an additional file name for semantic release icon: `release.config.cjs`.
This file name format is supported out of the box by semantic release.
That means, it detects it automatically and we don't need to declare something like `... -c ./release.config.cjs`