### PR TITLE
Update package structure of npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,10 @@
   "main": "./dist/extension",
   "browser": "./dist/web/extension.js",
   "sideEffects": false,
+  "files": [
+    "icons",
+    "dist/material-icons.json"
+  ],
   "contributes": {
     "iconThemes": [
       {


### PR DESCRIPTION
Update the structure of the npm module to only include necessary parts of the icon theme (without the source code which is only needed for the VS Code extension):

![image](https://user-images.githubusercontent.com/12248527/234194591-452d4ba5-bce6-4ff2-81dc-38b25d295bbb.png)


