### PR TITLE
chore: Add `Dockerfile` with capital D

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -486,6 +486,7 @@ export const fileIcons: FileIcons = {
       fileExtensions: [
         'dockerignore',
         'dockerfile',
+        'Dockerfile',
         'docker-compose.yml',
         'docker-compose.yaml',
         'compose.yaml',
@@ -493,6 +494,7 @@ export const fileIcons: FileIcons = {
       ],
       fileNames: [
         'dockerfile',
+        'Dockerfile',
         'dockerfile.prod',
         'dockerfile.production',
         'dockerfile.alpha',


### PR DESCRIPTION
As per common docker convention, plain Dockerfiles are often capitalized (this, I have seen, can get carried into extensions)

This PR uses the existing icon for teams following this convention (including my own 😉)