### PR TITLE
fix: `nginx` file extensions typo

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1968,7 +1968,7 @@ export const fileIcons: FileIcons = {
     {
       name: 'nginx',
       fileNames: ['nginx.conf'],
-      fileExtensions: ['nginx', 'nginxconfig'],
+      fileExtensions: ['nginx', 'nginxconf'],
     },
     {
       name: 'minecraft',

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1968,7 +1968,7 @@ export const fileIcons: FileIcons = {
     {
       name: 'nginx',
       fileNames: ['nginx.conf'],
-      fileExtensions: ['nginx', 'nginxconf'],
+      fileExtensions: ['nginx', 'nginxconf', 'nginxconfig'],
     },
     {
       name: 'minecraft',


### PR DESCRIPTION
Determine that `nginxconfig` should be changed to `nginxconf` based on the following content.

https://github.com/joedeandev/prettier-plugin-nginx/commit/a547fafa62ca7986f1fde2fda31758a64d983ad3
https://github.com/joedeandev/prettier-plugin-nginx/blob/b3c840f4bac1373c2dc984825e3dad3308fcbcbe/src/index.ts#L84