### PR TITLE
Add git icon to .keep

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -673,6 +673,7 @@ export const fileIcons: FileIcons = {
         '.gitmodules',
         '.gitkeep',
         '.keep',
+        '.gitpreserve',
         '.gitinclude',
         '.git-blame-ignore',
         '.git-blame-ignore-revs',

--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -672,6 +672,7 @@ export const fileIcons: FileIcons = {
         '.gitconfig',
         '.gitmodules',
         '.gitkeep',
+        '.keep',
         '.gitinclude',
         '.git-blame-ignore',
         '.git-blame-ignore-revs',


### PR DESCRIPTION
This adds the git icon to `.keep` files. Are there any other git files that are missing? 
Should I also add `.gitpreserve`?