### PR TITLE
Associate `.tfbackend` files with Terraform

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -915,7 +915,7 @@ export const fileIcons: FileIcons = {
     },
     {
       name: 'terraform',
-      fileExtensions: ['tf', 'tf.json', 'tfvars', 'tfstate'],
+      fileExtensions: ['tf', 'tf.json', 'tfvars', 'tfstate', 'tfbackend'],
     },
     {
       name: 'laravel',


### PR DESCRIPTION
Closes #2052.