### PR TITLE
[Icon Request] Add icon association to dockercompose language id

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -67,13 +67,7 @@ export const fileIcons: FileIcons = {
     { name: 'twine', fileExtensions: ['tw', 'twee'] },
     {
       name: 'yaml',
-      fileExtensions: [
-        'yml',
-        'yaml',
-        'yml.dist',
-        'yaml.dist',
-        'YAML-tmLanguage',
-      ],
+      fileExtensions: ['yml.dist', 'yaml.dist', 'YAML-tmLanguage'],
     },
     {
       name: 'xml',

--- a/src/icons/languageIcons.ts
+++ b/src/icons/languageIcons.ts
@@ -87,7 +87,7 @@ export const languageIcons: LanguageIcon[] = [
   { icon: { name: 'tex' }, ids: ['tex', 'doctex', 'latex', 'latex-expl3'] },
   { icon: { name: 'salesforce' }, ids: ['apex'] },
   { icon: { name: 'sas' }, ids: ['sas'] },
-  { icon: { name: 'docker' }, ids: ['dockerfile'] },
+  { icon: { name: 'docker' }, ids: ['dockerfile', 'dockercompose'] },
   { icon: { name: 'table' }, ids: ['csv', 'tsv', 'psv'] },
   { icon: { name: 'csharp' }, ids: ['csharp'] },
   { icon: { name: 'console' }, ids: ['bat', 'awk', 'shellscript'] },


### PR DESCRIPTION
## Changes

- Add dockercompose language id to docker icon
- Remove yml and yaml extensions from file icon association as they will also detected via language id automatically and will not produce a conflict with the `compose.*.yaml` files

Locally tested and it works automatically:

![image](https://github.com/PKief/vscode-material-icon-theme/assets/12248527/2af73c32-6468-442b-b0cb-805ec95c5e1b)

If the automatic detection might not work for some users, they can add this config to their user or workspace settings and it will force VS Code to apply the language id to these files names (interestingly here VS Code supports the glob pattern):

```json
"files.associations": {
    "compose.*.yaml": "dockercompose"
}
```

And then this extension finally maps the icon to the language id and applies it to all files which are associated with this id.