### PR TITLE
Add missing language ids for yaml icon

### DIFF
--- a/src/icons/languageIcons.ts
+++ b/src/icons/languageIcons.ts
@@ -7,7 +7,12 @@ export const languageIcons: LanguageIcon[] = [
   { icon: { name: 'git' }, ids: ['git', 'git-commit', 'git-rebase', 'ignore'] },
   {
     icon: { name: 'yaml' },
-    ids: ['yaml', 'github-actions-workflow', 'spring-boot-properties-yaml'],
+    ids: [
+      'yaml',
+      'github-actions-workflow',
+      'spring-boot-properties-yaml',
+      'jinja-yaml',
+    ],
   },
   { icon: { name: 'xml' }, ids: ['xml', 'xquery', 'xsl'] },
   { icon: { name: 'matlab' }, ids: ['matlab'] },

--- a/src/icons/languageIcons.ts
+++ b/src/icons/languageIcons.ts
@@ -5,12 +5,15 @@ import { LanguageIcon } from '../models';
  */
 export const languageIcons: LanguageIcon[] = [
   { icon: { name: 'git' }, ids: ['git', 'git-commit', 'git-rebase', 'ignore'] },
-  { icon: { name: 'yaml' }, ids: ['yaml', 'github-actions-workflow'] },
+  {
+    icon: { name: 'yaml' },
+    ids: ['yaml', 'github-actions-workflow', 'spring-boot-properties-yaml'],
+  },
   { icon: { name: 'xml' }, ids: ['xml', 'xquery', 'xsl'] },
   { icon: { name: 'matlab' }, ids: ['matlab'] },
   {
     icon: { name: 'settings' },
-    ids: ['makefile', 'toml', 'ini', 'properties'],
+    ids: ['makefile', 'toml', 'ini', 'properties', 'spring-boot-properties'],
   },
   { icon: { name: 'shaderlab' }, ids: ['shaderlab'] },
   { icon: { name: 'diff' }, ids: ['diff'] },

--- a/src/icons/languageIcons.ts
+++ b/src/icons/languageIcons.ts
@@ -5,7 +5,7 @@ import { LanguageIcon } from '../models';
  */
 export const languageIcons: LanguageIcon[] = [
   { icon: { name: 'git' }, ids: ['git', 'git-commit', 'git-rebase', 'ignore'] },
-  { icon: { name: 'yaml' }, ids: ['yaml'] },
+  { icon: { name: 'yaml' }, ids: ['yaml', 'github-actions-workflow'] },
   { icon: { name: 'xml' }, ids: ['xml', 'xquery', 'xsl'] },
   { icon: { name: 'matlab' }, ids: ['matlab'] },
   {


### PR DESCRIPTION
Associate following language ids with yaml icon:

- github-actions-workflow
- jinja-yaml
- spring-boot-properties-yaml

Closes #2064 