### PR TITLE
Support OWNERS files

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1862,7 +1862,7 @@ export const fileIcons: FileIcons = {
     { name: 'advpl_ptm', fileExtensions: ['ptm'] },
     { name: 'advpl_tlpp', fileExtensions: ['tlpp'] },
     { name: 'advpl_include', fileExtensions: ['ch'] },
-    { name: 'codeowners', fileNames: ['codeowners'] },
+    { name: 'codeowners', fileNames: ['codeowners', 'OWNERS'] },
     { name: 'gcp', fileNames: ['.gcloudignore'] },
     {
       name: 'disc',


### PR DESCRIPTION
Adds support for [OWNERS](https://gerrit.googlesource.com/plugins/find-owners/+/master/src/main/resources/Documentation/syntax.md) files. similar to `codeowners` but a google-ism. This PR just reuses the icon for `codeowners`