### PR TITLE
Added mjs extension for stylelint

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1469,6 +1469,7 @@ export const fileIcons: FileIcons = {
         '.stylelintrc',
         'stylelint.config.js',
         'stylelint.config.cjs',
+        'stylelint.config.mjs',
         '.stylelintrc.json',
         '.stylelintrc.yaml',
         '.stylelintrc.yml',


### PR DESCRIPTION
This fixes the definition of stylelint files with the mjs extension as just js files.

![image](https://github.com/PKief/vscode-material-icon-theme/assets/48956742/bf1f7534-44c0-41ed-9550-9e21c5fbd86d)
