### PR TITLE
chore: add "protobuf" to proto folder names

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -862,7 +862,7 @@ export const folderIcons: FolderTheme[] = [
       },
       {
         name: 'folder-proto',
-        folderNames: ['protobufs', 'proto'],
+        folderNames: ['protobuf', 'protobufs', 'proto', 'protos'],
       },
       {
         name: 'folder-plastic',


### PR DESCRIPTION
`protobuf` / `protos` are commonly used names alongside `protobufs`/`proto` 

(See https://github.com/protocolbuffers/protobuf/tree/main/src/google/protobuf)