### PR TITLE
add photo (and variants) to folderIcons.ts

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -53,6 +53,10 @@ export const folderIcons: FolderTheme[] = [
           'pics',
           'picture',
           'pictures',
+          'photo',
+          'photos',
+          'photograph'
+          'photographs'
         ],
       },
       {

--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -55,8 +55,8 @@ export const folderIcons: FolderTheme[] = [
           'pictures',
           'photo',
           'photos',
-          'photograph'
-          'photographs'
+          'photograph',
+          'photographs',
         ],
       },
       {


### PR DESCRIPTION
Associates `photo`, `photos`, `photograph`, and `photographs` folder names with the same icon as `pic`, `pics`, `picture`, and `pictures`.