### PR TITLE
chore: add `svg-color-linter` to check-colors before requesting merge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,17 +6,12 @@ Glad you're here and interested in expanding this project 🎉 In order to make 
 
 - [Icon Requests](#icon-requests)
 - [Add new icons](#add-new-icons)
-- [How-To's](#how-tos)
-  - [Create icon as SVG](#create-icon-as-svg)
-  - [Use Material Design colors](#material-design-colors)
-  - [Design folder icons](#design-folder-icons)
-  - [Icon spacing](#icon-spacing)
-  - [Icons for color themes](#icons-for-color-themes)
-  - [Unique assignment to file and folder names](#icon-assignments)
-  - [Create icon packs](#icon-packs)
-  - [Designing Pixel Perfect Icons](#pixel-perfect-icons)
+- [How tos](#how-tos)
+    - [File icons](#file-icons)
+    - [Folder icons](#folder-icons)
+    - [Language icons](#language-icons)
 - [Add translations](#add-translations)
-- [Update API](#update-api)
+- [Debug extension locally](#debug-extension-locally)
 
 <!-- /TOC -->
 
@@ -71,6 +66,12 @@ Of course, there is also the possibility to add existing SVGs. Mostly, however, 
 An important success factor of this icon extension is the fact that all colors fit together harmoniously. This is due to the fact that all icons exist only from colors of the [Material Design color palette](https://material.io/design/color/the-color-system.html#tools-for-picking-colors). This creates nice contrasts and the icons are easily recognizable.
 
 Now it often happens that many programming languages already have icons with their own colors. To find the matching color from the Material Design color palette based on a known color, there is the [Material Color Converter](https://pkief.github.io/material-color-converter/). With its help any color can be converted into a Material Design color.
+
+You can check if your icon fits to the Material Design color palette by running the follwing command:
+
+```sh
+npm run check-colors <path/to/svg>
+```
 
 Continue reading [here](#design-folder-icons) to find out about colors for the folder icons.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "prettier": "^2.6.2",
         "puppeteer": "^14.1.1",
         "rimraf": "^3.0.2",
+        "svg-color-linter": "^1.3.0",
         "svgo": "^2.8.0",
         "ts-loader": "^9.3.0",
         "ts-node": "^10.8.0",
@@ -1173,6 +1174,12 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
+    "node_modules/chroma-js": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
+      "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A==",
+      "dev": true
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -1948,6 +1955,28 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.5.tgz",
+      "integrity": "sha512-sWvP1Pl8H03B8oFJpFR3HE31HUfwtX7Rlf9BNsvdpujD4n7WMhfmu8h9wOV2u+c1k0ZilTADhPqypzx2J690ZQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -2534,6 +2563,21 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-svg": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-4.4.0.tgz",
+      "integrity": "sha512-v+AgVwiK5DsGtT9ng+m4mClp6zDAmwrW8nZi6Gg15qzvBnRWWdfWA1TGaXyCDnWq5g5asofIgMVl3PjKxvk1ug==",
+      "dev": true,
+      "dependencies": {
+        "fast-xml-parser": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -3741,6 +3785,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3751,6 +3801,49 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/svg-color-linter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/svg-color-linter/-/svg-color-linter-1.3.0.tgz",
+      "integrity": "sha512-GKSKWfmhSx9uf9Na6aCrwUIWBtDi/AgRCbmw0XFxzmPJg5+bUF9ZlVfA/ujGL3mdr1Gx63E4IvlEPshbV1jRHA==",
+      "dev": true,
+      "dependencies": {
+        "chroma-js": "^2.2.0",
+        "glob": "^7.2.0",
+        "is-glob": "^4.0.3",
+        "is-svg": "^4.3.2",
+        "js-yaml": "^4.1.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "svg-color-linter": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/pkief"
+      }
+    },
+    "node_modules/svg-color-linter/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/svgo": {
@@ -5311,6 +5404,12 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
+    "chroma-js": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
+      "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A==",
+      "dev": true
+    },
     "chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -5903,6 +6002,15 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-xml-parser": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.5.tgz",
+      "integrity": "sha512-sWvP1Pl8H03B8oFJpFR3HE31HUfwtX7Rlf9BNsvdpujD4n7WMhfmu8h9wOV2u+c1k0ZilTADhPqypzx2J690ZQ==",
+      "dev": true,
+      "requires": {
+        "strnum": "^1.0.5"
+      }
+    },
     "fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -6327,6 +6435,15 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
       "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
       "dev": true
+    },
+    "is-svg": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-4.4.0.tgz",
+      "integrity": "sha512-v+AgVwiK5DsGtT9ng+m4mClp6zDAmwrW8nZi6Gg15qzvBnRWWdfWA1TGaXyCDnWq5g5asofIgMVl3PjKxvk1ug==",
+      "dev": true,
+      "requires": {
+        "fast-xml-parser": "^4.1.3"
+      }
     },
     "is-unicode-supported": {
       "version": "0.1.0",
@@ -7207,6 +7324,12 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7214,6 +7337,36 @@
       "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
+      }
+    },
+    "svg-color-linter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/svg-color-linter/-/svg-color-linter-1.3.0.tgz",
+      "integrity": "sha512-GKSKWfmhSx9uf9Na6aCrwUIWBtDi/AgRCbmw0XFxzmPJg5+bUF9ZlVfA/ujGL3mdr1Gx63E4IvlEPshbV1jRHA==",
+      "dev": true,
+      "requires": {
+        "chroma-js": "^2.2.0",
+        "glob": "^7.2.0",
+        "is-glob": "^4.0.3",
+        "is-svg": "^4.3.2",
+        "js-yaml": "^4.1.0",
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "svgo": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "npm run compile:dev && npm run generateJson",
     "check": "ts-node ./src/scripts/icons/checks",
+    "check-colors": "svg-color-linter --colors material-colors.yml",
     "compile": "webpack --config ./build/webpack.config.js --mode production",
     "compile:dev": "webpack --config ./build/webpack.config.js --mode none",
     "compile:watch": "webpack --config ./build/webpack.config.js --mode none --watch",
@@ -259,6 +260,7 @@
     "prettier": "^2.6.2",
     "puppeteer": "^14.1.1",
     "rimraf": "^3.0.2",
+    "svg-color-linter": "^1.3.0",
     "svgo": "^2.8.0",
     "ts-loader": "^9.3.0",
     "ts-node": "^10.8.0",


### PR DESCRIPTION
This PR added `svg-color-linter` which was used in the CI `color-check`, to ensure that the contributors can pre-check the color system before requesting a review. Also, added it to contributing.md

Note: Left out the CI to continue to use npx instead of installing the whole dependencies.