### PR TITLE
feat: add postcss .mjs extension support

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -952,10 +952,12 @@ export const fileIcons: FileIcons = {
       fileNames: [
         'postcss.config.js',
         'postcss.config.cjs',
+        'postcss.config.mjs',
         'postcss.config.ts',
         'postcss.config.cts',
         '.postcssrc.js',
         '.postcssrc.cjs',
+        '.postcssrc.mjs',
         '.postcssrc.ts',
         '.postcssrc.cts',
         '.postcssrc',


### PR DESCRIPTION
Add postcss support for `.mjs`

<img width="263" alt="Screenshot 2024-03-01 at 10 42 53 PM" src="https://github.com/PKief/vscode-material-icon-theme/assets/3688905/50b55a2e-b72d-4b23-842c-f9f4574b231b">
