### PR TITLE
feat: add commitlint .mjs extension support

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1953,6 +1953,7 @@ export const fileIcons: FileIcons = {
       fileNames: [
         '.commitlintrc',
         '.commitlintrc.js',
+        '.commitlintrc.mjs',
         '.commitlintrc.cjs',
         '.commitlintrc.ts',
         '.commitlintrc.cts',
@@ -1962,6 +1963,7 @@ export const fileIcons: FileIcons = {
         '.commitlint.yaml',
         '.commitlint.yml',
         'commitlint.config.js',
+        'commitlint.config.mjs',
         'commitlint.config.cjs',
         'commitlint.config.ts',
         'commitlint.config.cts',


### PR DESCRIPTION
Add commitlint `.mjs` extension support

![Screenshot 2024-03-04 at 11 46 04 AM](https://github.com/PKief/vscode-material-icon-theme/assets/3688905/5c6ecccc-c622-49ee-9c48-9097803f6fbd)


It is in the supported config files

https://commitlint.js.org/reference/configuration.html#config-via-file
```diff
.commitlintrc
.commitlintrc.json
.commitlintrc.yaml
.commitlintrc.yml
.commitlintrc.js
.commitlintrc.cjs
+.commitlintrc.mjs
.commitlintrc.ts
.commitlintrc.cts
commitlint.config.js
commitlint.config.cjs
+commitlint.config.mjs
commitlint.config.ts
commitlint.config.cts
```



