### PR TITLE
feat: add lighthouserc .cjs extension support

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -2313,6 +2313,8 @@ export const fileIcons: FileIcons = {
       fileNames: [
         '.lighthouserc.js',
         'lighthouserc.js',
+        '.lighthouserc.cjs',
+        'lighthouserc.cjs',
         '.lighthouserc.json',
         'lighthouserc.json',
         '.lighthouserc.yml',


### PR DESCRIPTION
The [lighthouse-ci](https://github.com/GoogleChrome/lighthouse-ci/tree/main) now [supports](https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/configuration.md#:~:text=.lighthouserc.cjs,lighthouserc.cjs) the .cjs file extension.