### PR TITLE
feat: add `.cjs` extension support for `gruntfile`

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -1613,6 +1613,8 @@ export const fileIcons: FileIcons = {
       fileNames: [
         'gruntfile.js',
         'gruntfile.ts',
+        'gruntfile.cjs',
+        'gruntfile.cts',
         'gruntfile.coffee',
         'gruntfile.babel.js',
         'gruntfile.babel.ts',


### PR DESCRIPTION
Add `.cjs` and `.cts` extensions for `gruntfile`s.

These extensions are used in projects that are defined as `type: "module"` in their `package.json`.