### PR TITLE
Add aliases for platform folders

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -662,9 +662,9 @@ export const folderIcons: FolderTheme[] = [
       },
       { name: 'folder-supabase', folderNames: ['supabase', '.supabase'] },
       { name: 'folder-private', folderNames: ['private', '.private'] },
-      { name: 'folder-linux', folderNames: ['linux'] },
-      { name: 'folder-windows', folderNames: ['windows'] },
-      { name: 'folder-macos', folderNames: ['macos', '.DS_Store'] },
+      { name: 'folder-linux', folderNames: ['linux', 'linuxbsd', 'unix'] },
+      { name: 'folder-windows', folderNames: ['windows', 'win'] },
+      { name: 'folder-macos', folderNames: ['macos', 'mac', '.DS_Store'] },
       {
         name: 'folder-error',
         folderNames: ['error', 'errors', 'err', 'errs', 'crash', 'crashes'],


### PR DESCRIPTION
Gives the linux/windows/macos folders a bit more wiggle-room in terms of use by adding extra platform names. The names aren't used anywhere else in the repo so there's no risk of overlapping existing elements.