### PR TITLE
feat: Add `.editorconfig` and `.gitattributes`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.svg]
+insert_final_newline = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Normalize EOL for all files that Git considers text files
+* text=auto eol=lf
+
+# Explicit binary files for older Git versions (<2.10)
+*.png binary
+*.gif binary


### PR DESCRIPTION
While format/eol desyncs haven't been a problem in the past, this is a safeguard to ensure it stays that way. Also, explicitly excludes `svg` files from getting a final newline, as those are meant to be saved in a compressed format.