### PR TITLE
Added `.server` & `.client` as valid folder qualifiers

### DIFF
--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -448,11 +448,11 @@ export const folderIcons: FolderTheme[] = [
       { name: 'folder-ansible', folderNames: ['ansible'] },
       {
         name: 'folder-server',
-        folderNames: ['server', 'servers', 'backend', 'backends'],
+        folderNames: ['.server', 'server', 'servers', 'backend', 'backends'],
       },
       {
         name: 'folder-client',
-        folderNames: ['client', 'clients', 'frontend', 'frontends', 'pwa'],
+        folderNames: ['.client', 'client', 'clients', 'frontend', 'frontends', 'pwa'],
       },
       { name: 'folder-tasks', folderNames: ['tasks', 'tickets'] },
       { name: 'folder-android', folderNames: ['android'] },

--- a/src/icons/folderIcons.ts
+++ b/src/icons/folderIcons.ts
@@ -452,7 +452,14 @@ export const folderIcons: FolderTheme[] = [
       },
       {
         name: 'folder-client',
-        folderNames: ['.client', 'client', 'clients', 'frontend', 'frontends', 'pwa'],
+        folderNames: [
+          '.client',
+          'client',
+          'clients',
+          'frontend',
+          'frontends',
+          'pwa',
+        ],
       },
       { name: 'folder-tasks', folderNames: ['tasks', 'tickets'] },
       { name: 'folder-android', folderNames: ['android'] },


### PR DESCRIPTION
In [Remix](https://remix.run), server-only or client-only modules can be bundled together under a [`.server`](https://remix.run/docs/en/main/file-conventions/-server) or `.client` module. Added folder icon support for them 😁 