### PR TITLE
feat: support biome.jsonc

### DIFF
--- a/src/icons/fileIcons.ts
+++ b/src/icons/fileIcons.ts
@@ -2292,7 +2292,7 @@ export const fileIcons: FileIcons = {
         'panda.config.cjs',
       ],
     },
-    { name: 'biome', fileNames: ['biome.json'] },
+    { name: 'biome', fileNames: ['biome.json', 'biome.jsonc'] },
     {
       name: 'esbuild',
       fileNames: [


### PR DESCRIPTION
Biome config file can be both `biome.json` and `biome.jsonc` (JSON with comments)

Reference: <https://biomejs.dev/guides/getting-started/#configuration>