### PR TITLE
Added `devcontainer.json`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,8 @@
       "extensions": [
         // Define suggested extensions to preinstall in the dev container
         "dbaeumer.vscode-eslint",
-        "esbenp.prettier-vscode"
+        "esbenp.prettier-vscode",
+        "jock.svg"
       ]
     }
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+  "name": "vscode-material-icon-theme",
+
+  // Use Microsoft's Ubuntu Base image for the dev container
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    // Use NodeJS features in the dev container
+    "ghcr.io/devcontainers/features/node:1": {}
+  },
+
+  "privileged": true,
+
+  "onCreateCommand": {
+    // Install NPM dependencies in the dev container
+    "install-node-packages": "npm install"
+  },
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        // Define suggested settings for the dev container
+        "resmon.show.battery": false,
+        "resmon.show.cpufreq": false
+      },
+      "extensions": [
+        // Define suggested extensions to preinstall in the dev container
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 
   "privileged": true,
 
-  "onCreateCommand": {
+  "postCreateCommand": {
     // Install NPM dependencies in the dev container
     "install-node-packages": "npm install"
   },


### PR DESCRIPTION
I've added a `devcontainer.json` to quickly start development on **GitHub Codespaces** so that dependencies are automatically installed when the Codespace is created.

What's special about **Codespaces** is that you can **instantly** start development on **any** project

But in this case it won't be instant, because it has to install dependencies before opening, and that takes time, so I advise you to enable **prebuilds** for **Codespaces** in the repository settings, this will allow developers to skip installing dependencies and start development in a completely ready-to-use environment, including with previously installed **vscode** extensions

Also, I strongly recommend adding the "[**Svg Preview**](https://marketplace.visualstudio.com/items?itemName=SimonSiefke.svg-preview)" extension to the pre-installation list, which **helps a lot** with icon previews

So I suggest you take a look at this **PR** and discuss how we can improve it