### PR TITLE
fix: 🚑 interop between cloned icons and user associations

### DIFF
--- a/src/icons/generator/fileGenerator.ts
+++ b/src/icons/generator/fileGenerator.ts
@@ -201,9 +201,10 @@ const setIconDefinition = (
 ) => {
   const obj: Partial<IconConfiguration> = { iconDefinitions: {} };
   const ext = isClone ? cloneIconExtension : '.svg';
-  if (config.options) {
+  const key = `${iconName}${appendix}`;
+  if (config.options && !config.iconDefinitions![key]) {
     const fileConfigHash = getFileConfigHash(config.options);
-    obj.iconDefinitions![`${iconName}${appendix}`] = {
+    obj.iconDefinitions![key] = {
       iconPath: `${iconFolderPath}${iconName}${appendix}${fileConfigHash}${ext}`,
     };
   }

--- a/src/icons/generator/folderGenerator.ts
+++ b/src/icons/generator/folderGenerator.ts
@@ -210,14 +210,21 @@ const createIconDefinitions = (
   const fileConfigHash = getFileConfigHash(config.options ?? {});
   const configIconDefinitions = config.iconDefinitions;
   const ext = isClone ? cloneIconExtension : '.svg';
+  const key = `${iconName}${appendix}`;
+  const openedKey = `${iconName}${openedFolder}${appendix}`;
 
   if (configIconDefinitions) {
-    configIconDefinitions[iconName + appendix] = {
-      iconPath: `${iconFolderPath}${iconName}${appendix}${fileConfigHash}${ext}`,
-    };
-    configIconDefinitions[`${iconName}${openedFolder}${appendix}`] = {
-      iconPath: `${iconFolderPath}${iconName}${openedFolder}${appendix}${fileConfigHash}${ext}`,
-    };
+    if (!configIconDefinitions[key]) {
+      configIconDefinitions[key] = {
+        iconPath: `${iconFolderPath}${key}${fileConfigHash}${ext}`,
+      };
+    }
+
+    if (!configIconDefinitions[`${openedKey}`]) {
+      configIconDefinitions[`${openedKey}`] = {
+        iconPath: `${iconFolderPath}${openedKey}${fileConfigHash}${ext}`,
+      };
+    }
   }
   return config;
 };

--- a/src/test/spec/icons/fileIcons.spec.ts
+++ b/src/test/spec/icons/fileIcons.spec.ts
@@ -311,4 +311,59 @@ describe('file icons', () => {
 
     deepStrictEqual(iconDefinitions, expectedConfig);
   });
+
+  it('should allow interoperability between cloned and user custom associations', () => {
+    const fileIcons: FileIcons = {
+      defaultIcon: { name: 'file' },
+      icons: [
+        {
+          name: 'foo',
+          fileExtensions: ['foo'],
+        },
+        {
+          name: 'bar',
+          fileExtensions: ['bar'],
+          clone: {
+            base: 'foo',
+            color: 'green-500',
+            lightColor: 'green-100',
+          },
+        },
+      ],
+    };
+
+    const options = getDefaultIconOptions();
+    options.files.associations = {
+      '*.baz': 'bar', // assigned to the clone
+    };
+
+    const iconConfig = merge({}, new IconConfiguration(), { options });
+    const iconDefinitions = loadFileIconDefinitions(
+      fileIcons,
+      iconConfig,
+      options
+    );
+
+    expectedConfig.options = options;
+    expectedConfig.iconDefinitions = {
+      foo: {
+        iconPath: './../icons/foo.svg',
+      },
+      bar: {
+        iconPath: './../icons/bar.clone.svg',
+      },
+      file: {
+        iconPath: './../icons/file.svg',
+      },
+    };
+    expectedConfig.fileNames = {};
+    expectedConfig.fileExtensions = {
+      foo: 'foo',
+      bar: 'bar',
+      baz: 'bar',
+    };
+    expectedConfig.file = 'file';
+
+    deepStrictEqual(iconDefinitions, expectedConfig);
+  });
 });

--- a/src/test/spec/icons/folderIcons.spec.ts
+++ b/src/test/spec/icons/folderIcons.spec.ts
@@ -642,4 +642,89 @@ describe('folder icons', () => {
 
     deepStrictEqual(iconDefinitions, expectedConfig);
   });
+
+  it('should allow interoperability between cloned and user custom associations', () => {
+    const folderTheme: FolderTheme[] = [
+      {
+        name: 'specific',
+        defaultIcon: { name: 'folder' },
+        rootFolder: { name: 'folder-root' },
+        icons: [
+          { name: 'folder-foo', folderNames: ['foo'] },
+          {
+            name: 'folder-bar',
+            folderNames: ['bar'],
+            clone: {
+              base: 'foo',
+              color: 'green-500',
+            },
+          },
+        ],
+      },
+    ];
+
+    const options = getDefaultIconOptions();
+    options.folders.associations = {
+      baz: 'bar', // assigned to the clone
+    };
+
+    const iconConfig = merge({}, new IconConfiguration(), { options });
+    const iconDefinitions = loadFolderIconDefinitions(
+      folderTheme,
+      iconConfig,
+      options
+    );
+
+    expectedConfig.options = options;
+    expectedConfig.iconDefinitions = {
+      'folder-foo': { iconPath: './../icons/folder-foo.svg' },
+      'folder-foo-open': { iconPath: './../icons/folder-foo-open.svg' },
+      'folder-bar': { iconPath: './../icons/folder-bar.clone.svg' },
+      'folder-bar-open': { iconPath: './../icons/folder-bar-open.clone.svg' },
+      folder: { iconPath: './../icons/folder.svg' },
+      'folder-open': { iconPath: './../icons/folder-open.svg' },
+      'folder-root': { iconPath: './../icons/folder-root.svg' },
+      'folder-root-open': { iconPath: './../icons/folder-root-open.svg' },
+    };
+    expectedConfig.folder = 'folder';
+    expectedConfig.folderExpanded = 'folder-open';
+    expectedConfig.rootFolder = 'folder-root';
+    expectedConfig.rootFolderExpanded = 'folder-root-open';
+    expectedConfig.folderNames = {
+      '.bar': 'folder-bar',
+      '.baz': 'folder-bar',
+      '.foo': 'folder-foo',
+      __bar__: 'folder-bar',
+      __baz__: 'folder-bar',
+      __foo__: 'folder-foo',
+      _bar: 'folder-bar',
+      _baz: 'folder-bar',
+      _foo: 'folder-foo',
+      bar: 'folder-bar',
+      baz: 'folder-bar',
+      foo: 'folder-foo',
+    };
+    expectedConfig.folderNamesExpanded = {
+      '.bar': 'folder-bar-open',
+      '.baz': 'folder-bar-open',
+      '.foo': 'folder-foo-open',
+      __bar__: 'folder-bar-open',
+      __baz__: 'folder-bar-open',
+      __foo__: 'folder-foo-open',
+      _bar: 'folder-bar-open',
+      _baz: 'folder-bar-open',
+      _foo: 'folder-foo-open',
+      bar: 'folder-bar-open',
+      baz: 'folder-bar-open',
+      foo: 'folder-foo-open',
+    };
+
+    expectedConfig.light = {
+      fileExtensions: {},
+      fileNames: {},
+    };
+    expectedConfig.hidesExplorerArrows = false;
+
+    deepStrictEqual(iconDefinitions, expectedConfig);
+  });
 });


### PR DESCRIPTION
Allow interoperability between icons cloned by the extension and custom user associations, so that cloned icons can be assigned via `material-icon-theme.[files|folders].associations` setting.

Ref: https://github.com/PKief/vscode-material-icon-theme/pull/2314#issuecomment-2104897492

![image](https://github.com/PKief/vscode-material-icon-theme/assets/12949236/d9f06a72-bd48-4dc7-9ec5-75937a0cb2d9)
