### PR TITLE
chore: provenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+---
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions' # See documentation for possible values
+    directory: '/' # Location of package manifests
+    schedule:
+      interval: 'weekly'
+    assignees:
+      - 'PKief'
+    groups:
+      github-actions:
+        patterns:
+          - 'actions/*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build + Test
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: [ubuntu-latest]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,14 @@ jobs:
 
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Setup Platform 🛠
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
-          bun-version: latest
+          bun-version: 1.1.13
 
       - name: Install dependencies 📦
         run: bun install --frozen-lockfile

--- a/.github/workflows/color-check.yml
+++ b/.github/workflows/color-check.yml
@@ -5,12 +5,16 @@ on:
     paths:
       - 'icons/*.svg'
 
+permissions:
+  contents: read
+
 jobs:
   color-check:
     name: SVG Color Check
     runs-on: ubuntu-latest
     env:
       TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
+
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/color-check.yml
+++ b/.github/workflows/color-check.yml
@@ -13,10 +13,11 @@ jobs:
       TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
-          
+          persist-credentials: false
+
       - name: Check colors 🎨
         run: |
           svgFiles=$(git diff origin/${{ env.TARGET_BRANCH }} --diff-filter=ACMRTUX  --name-only | grep '.svg$')

--- a/.github/workflows/icon-review.yml
+++ b/.github/workflows/icon-review.yml
@@ -5,12 +5,19 @@ on:
     paths:
       - 'icons/*.svg'
 
+permissions:
+  contents: read
+
 jobs:
   icon-review:
     name: Icon Review
     runs-on: ubuntu-latest
     env:
       TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
+
+    permissions:
+      pull-requests: write
+
     steps:
       - name: Checkout Fork 🛎️
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/icon-review.yml
+++ b/.github/workflows/icon-review.yml
@@ -13,18 +13,20 @@ jobs:
       TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
     steps:
       - name: Checkout Fork 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
           path: fork
+          persist-credentials: false
 
       - name: Checkout Original 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
           path: main
+          persist-credentials: false
 
       - name: Review SVG files 🔍
         run: |
@@ -46,7 +48,7 @@ jobs:
         shell: bash
 
       - name: Post review in PR ✍️
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const image_url = "${{ env.image_url }}";

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -11,16 +11,16 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
       - name: Post Thank You Comment 🙏
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## Merge Successful 
-              
-              Thanks for your contribution! 🎉 
-              
+              body: `## Merge Successful
+
+              Thanks for your contribution! 🎉
+
               The changes will be part of the upcoming update on the marketplace.`
             })

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -5,10 +5,17 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+
 jobs:
   thank_you:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
+
+    permissions:
+      pull-requests: write
+
     steps:
       - name: Post Thank You Comment 🙏
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,14 +47,14 @@ jobs:
           git config --global push.followTags true
           npm version ${{ env.VERSION_CHANGE }} -m "Release %s"
 
-      - name: Get meta data 🔍
+      - name: Get metadata 🔍
         run: |
-          NODE_VERSION=$(node -p -e "require('./package.json').version")
-          echo VERSION=$NODE_VERSION >> $GITHUB_ENV
-          NODE_NAME=$(node -p -e "require('./package.json').name")
-          echo NAME=$NODE_NAME >> $GITHUB_ENV
-          NODE_DISPLAY_NAME=$(node -p -e "require('./package.json').displayName")
-          echo DISPLAY_NAME=$NODE_DISPLAY_NAME >> $GITHUB_ENV
+          VERSION=$(bun --print "(await import('./package.json')).version")
+          NAME=$(bun --print "(await import('./package.json')).name")
+          DISPLAY_NAME=$(bun --print "(await import('./package.json')).displayName")
+          echo VERSION=$VERSION >> $GITHUB_ENV
+          echo NAME=$NAME >> $GITHUB_ENV
+          echo DISPLAY_NAME=$DISPLAY_NAME >> $GITHUB_ENV
 
       - name: Build ⚒️
         run: bunx @vscode/vsce package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,18 +18,22 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERSION_CHANGE: ${{ github.event.inputs.versionChange }}
+
     permissions:
+      contents: write
       id-token: write
+
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Platform 🛠
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
-          bun-version: latest
+          bun-version: 1.1.13
 
       - name: Install dependencies 📦
         run: |
@@ -59,7 +63,7 @@ jobs:
         run: git push
 
       - name: Release ${{ env.VERSION }} 🔆
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
         with:
           files: ${{ env.NAME }}-${{ env.VERSION }}.vsix
           tag_name: v${{ env.VERSION }}
@@ -67,13 +71,13 @@ jobs:
           generate_release_notes: true
 
       - name: Publish to Open VSX Registry 🌐
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@28e2d3f5817fccf23c1f219eb0cecc903132d1a2 # v1.6.2
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           extensionFile: ${{ env.NAME }}-${{ env.VERSION }}.vsix
 
       - name: Publish to Visual Studio Marketplace 🌐
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@28e2d3f5817fccf23c1f219eb0cecc903132d1a2 # v1.6.2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ on:
           - minor
           - patch
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERSION_CHANGE: ${{ github.event.inputs.versionChange }}
+    permissions:
+      id-token: write
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
@@ -80,4 +82,4 @@ jobs:
       - name: Publish to NPM Registry 🌐
         run: |
           npm set "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}"
-          npm publish
+          npm publish --provenance --access public

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,11 +6,11 @@
     "out": true
   },
   "[typescript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features",
     "editor.codeActionsOnSave": {
       "quickfix.biome": "explicit",
       "source.organizeImports.biome": "explicit"
     }
   },
+  "editor.defaultFormatter": "biomejs.biome",
   "editor.formatOnSave": true
 }


### PR DESCRIPTION
I decided to look at the diff for 314aba7ba73d32293cf4608e0319beab5f2d4c18 and noticed it touched automated publishing. This is minor improvement to that flow that allows consumers to verify that the code did come from github actions, and wasn't created locally with a backdoor. This can prevent certain _very_ specific supply-chain attacks.
I don't know why anyone would care, but someone probably will eventually complain, so it's better to do it now than latter. Although, in all seriousness, there are much better vectors for breaking into builds, and this doesn't help much without SHA pinning (I can do as well that if you'd like). Nevertheless, It doesn't hurt anything and I already had the the tab open 🙃